### PR TITLE
CORE-1452: added a maximum_concurrent_requests_per_user column

### DIFF
--- a/migrations/000023_request_type_limit.down.sql
+++ b/migrations/000023_request_type_limit.down.sql
@@ -2,8 +2,11 @@ BEGIN;
 
 SET search_path = public, pg_catalog;
 
--- Remove the `maximum_requests_per_user` column from the `request_types` table.
+-- Remove the `maximum_requests_per_user` and `maximum_concurrent_requests_per_user` columns from the `request_types`
+-- table.
 ALTER TABLE IF EXISTS request_types
 DROP COLUMN IF EXISTS maximum_requests_per_user;
+ALTER TABLE IF EXISTS request_types
+DROP COLUMN IF EXISTS maximum_concurrent_requests_per_user;
 
 COMMIT

--- a/migrations/000023_request_type_limit.up.sql
+++ b/migrations/000023_request_type_limit.up.sql
@@ -2,13 +2,15 @@ BEGIN;
 
 SET search_path = public, pg_catalog;
 
--- Add the `maximum_requests_per_user` column to the `request_types` table.
+-- Add the `maximum_requests_per_user` and `maximum_concurrent_requests_per_user` columns to the `request_types` table.
 ALTER TABLE IF EXISTS request_types
 ADD COLUMN IF NOT EXISTS maximum_requests_per_user int;
+ALTER TABLE IF EXISTS request_types
+ADD COLUMN IF NOT EXISTS maximum_concurrent_requests_per_user int;
 
--- Set the limit for VICE access request to 1 if the request type exists.
+-- Set the initial limits for VICE access requests if the request type exists.
 UPDATE request_types
-SET maximum_requests_per_user = 1
+SET maximum_requests_per_user = 10, maximum_concurrent_requests_per_user = 1
 WHERE name = 'vice';
 
 COMMIT


### PR DESCRIPTION
Since migration number 23 has only been applied to the QA database for now, I added this change to that conversion.
