### PR TITLE
Add migration and README update for CPU usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,44 @@
 # Database Schema for the Discovery Environment
 
-This repository contains the database migration files for the relational database used by the CyVerse Discovery Environment. This is the successor to the former four databases for assorted Discovery Environment services ([de][1], [metadata][2], [permissions][3], and [notifications][4]), now in schemas within one database. For reference, these older DB schemas and migrations are available in the `old-databases` folder. `notifications-db-v2` refers to the `v2` branch of the old notifications DB schema; all others refer to the primary branch of their respective databases.
+This repository contains the database migration files for the relational
+database used by the CyVerse Discovery Environment. This is the successor to the
+former four databases for assorted Discovery Environment services ([de][1],
+[metadata][2], [permissions][3], and [notifications][4]), now in schemas within
+one database. For reference, these older DB schemas and migrations are available
+in the `old-databases` folder. `notifications-db-v2` refers to the `v2` branch
+of the old notifications DB schema; all others refer to the primary branch of
+their respective databases.
 
-The migrations use the [golang-migrate/migrate][5] system and are stored within the `migrations` folder. They're written as pairs of simple SQL files, one each for applying and reverting each migration.
+The migrations use the [golang-migrate/migrate][5] system and are stored within
+the `migrations` folder. They're written as pairs of simple SQL files, one each
+for applying and reverting each migration.
 
 ## Prerequisites
 
 Before migrations can be run, the following need to be met:
 
 - The database must exist.
-- The account being used to access must be the owner of the database and relevant schemas.
-- The `uuid-ossp` extension must already be installed in the database by a superuser.
+- The account being used to access must be the owner of the database and
+  relevant schemas.
+- The `uuid-ossp` extension must already be installed in the database by a
+  superuser.
+- The `moddatetime` extension must already be installed in the database by a
+  superuser.
 
 ## Database URLs
 
-The `migrate` command requires a database URL to be able to connect to the database. The URL is in the format,
+The `migrate` command requires a database URL to be able to connect to the
+database. The URL is in the format,
 
 ```
 postgres://user:password@host:port/database-name?query-params
 ```
 
-The password component of the URL is optional, so if you have a correctly configured `.pgpass` file available then it
-can be omitted. Also, we haven't implemented SSL for any of our PostgreSQL instances, so the `sslmode` parameter should
-always be set to `disable` at this time. Here's an example of a database URL that we might use in one of our deployments
-(with a bogus host name).
+The password component of the URL is optional, so if you have a correctly
+configured `.pgpass` file available then it can be omitted. Also, we haven't
+implemented SSL for any of our PostgreSQL instances, so the `sslmode` parameter
+should always be set to `disable` at this time. Here's an example of a database
+URL that we might use in one of our deployments (with a bogus host name).
 
 ```
 postgres://de@postgres.example.org/de?sslmode=disable.
@@ -31,7 +46,8 @@ postgres://de@postgres.example.org/de?sslmode=disable.
 
 ## Common Examples
 
-These examples use the environment variable, `DBURL`, to indicate where the URL should be specified on the command line.
+These examples use the environment variable, `DBURL`, to indicate where the URL
+should be specified on the command line.
 
 Update the database to the latest version:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Before migrations can be run, the following need to be met:
   superuser.
 - The `moddatetime` extension must already be installed in the database by a
   superuser.
+- The `btree_gist` extension must already be installed in the database by a
+  superuser.
 
 ## Database URLs
 

--- a/migrations/000024_cpu_usage.down.sql
+++ b/migrations/000024_cpu_usage.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DROP TRIGGER IF EXISTS cpu_usage_event_types_last_modified_trigger ON cpu_usage_event_types CASCADE;
+DROP TRIGGER IF EXISTS cpu_usage_events_last_modified_trigger ON cpu_usage_events CASCADE;
+DROP TRIGGER IF EXISTS cpu_usage_totals_last_modified_trigger ON cpu_usage_totals CASCADE;
+
+DROP TABLE IF EXISTS cpu_usage_events;
+DROP TABLE IF EXISTS cpu_usage_totals;
+DROP TABLE IF EXISTS cpu_usage_event_types;
+
+COMMIT;

--- a/migrations/000024_cpu_usage.up.sql
+++ b/migrations/000024_cpu_usage.up.sql
@@ -25,6 +25,8 @@ CREATE TABLE IF NOT EXISTS cpu_usage_events (
     value bigint NOT NULL,
     created_by uuid NOT NULL,
     last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    UNIQUE (created_by, event_type_id, record_date, effective_date),
 
     FOREIGN KEY (event_type_id) REFERENCES cpu_usage_event_types(id),
     FOREIGN KEY (created_by) REFERENCES users(id),
@@ -44,6 +46,8 @@ CREATE TABLE IF NOT EXISTS cpu_usage_totals (
     effective_start_date timestamp NOT NULL,
     effective_end_date timestamp NOT NULL,
     last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE (user_id, effective_start_date, effective_end_date),
 
     FOREIGN KEY (user_id) REFERENCES users(id),
     PRIMARY KEY (id)

--- a/migrations/000024_cpu_usage.up.sql
+++ b/migrations/000024_cpu_usage.up.sql
@@ -43,11 +43,10 @@ CREATE TABLE IF NOT EXISTS cpu_usage_totals (
     id uuid NOT NULL DEFAULT uuid_generate_v4(),
     user_id uuid NOT NULL,
     total bigint NOT NULL DEFAULT 0,
-    effective_start_date timestamp NOT NULL,
-    effective_end_date timestamp NOT NULL,
+    effective_range tsrange NOT NULL,
     last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    UNIQUE (user_id, effective_start_date, effective_end_date),
+    CONSTRAINT effective_range_exclusion EXCLUDE USING GIST (user_id WITH =, effective_range WITH &&),
 
     FOREIGN KEY (user_id) REFERENCES users(id),
     PRIMARY KEY (id)

--- a/migrations/000024_cpu_usage.up.sql
+++ b/migrations/000024_cpu_usage.up.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+CREATE TABLE IF NOT EXISTS cpu_usage_event_types (
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    name character varying(32) NOT NULL,
+    description text,
+    last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY(id)
+);
+
+DROP TRIGGER IF EXISTS cpu_usage_event_types_last_modified_trigger ON cpu_usage_event_types CASCADE;
+CREATE TRIGGER cpu_usage_event_types_last_modified_trigger
+    BEFORE UPDATE ON cpu_usage_event_types
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (last_modified);
+
+CREATE TABLE IF NOT EXISTS cpu_usage_events (
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    record_date timestamp NOT NULL,
+    effective_date timestamp NOT NULL,
+    event_type_id uuid NOT NULL,
+    value bigint NOT NULL,
+    created_by uuid NOT NULL,
+    last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (event_type_id) REFERENCES cpu_usage_event_types(id),
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    PRIMARY KEY (id)
+);
+
+DROP TRIGGER IF EXISTS cpu_usage_events_last_modified_trigger ON cpu_usage_events CASCADE;
+CREATE TRIGGER cpu_usage_events_last_modified_trigger
+    BEFORE UPDATE ON cpu_usage_events
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (last_modified);
+
+CREATE TABLE IF NOT EXISTS cpu_usage_totals (
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    user_id uuid NOT NULL,
+    total bigint NOT NULL DEFAULT 0,
+    effective_start_date timestamp NOT NULL,
+    effective_end_date timestamp NOT NULL,
+    last_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    PRIMARY KEY (id)
+);
+
+DROP TRIGGER IF EXISTS cpu_usage_totals_last_modified_trigger ON cpu_usage_totals CASCADE;
+CREATE TRIGGER cpu_usage_totals_last_modified_trigger
+    BEFORE UPDATE ON cpu_usage_totals
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (last_modified);
+
+COMMIT;


### PR DESCRIPTION
Adds up and down migration for the following tables:
* cpu_usage_event_types
* cpu_usage_events
* cpu_usage_totals

Requires that the moddatetime extension be installed.
Adds triggers that update the last_modified field with moddatetime output.
Updates the README to mention the moddatetime prerequisite.