### PR TITLE
Add migration to add the millicores_reserved column to the jobs table

### DIFF
--- a/migrations/000027_millicores_reserved.down.sql
+++ b/migrations/000027_millicores_reserved.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS ONLY jobs
+    DROP IF EXISTS millicores_reserved CASCADE;
+
+COMMIT;

--- a/migrations/000027_millicores_reserved.up.sql
+++ b/migrations/000027_millicores_reserved.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS ONLY jobs 
+    ADD IF NOT EXISTS millicores_reserved int NOT NULL DEFAULT 0;
+
+COMMIT;


### PR DESCRIPTION
I debated whether or not this should be a bigint or not, but decided that was being a little too optimistic about our system's capabilities. 

I defaulted the value to 0 rather than one of the configured default values because I halfway suspect that our default values will change over time and so that we can see when the value is getting populated by services rather than just having the default set.