### PR TITLE
Add a migration 29 that fixes the user data usage last_modified trigger

### DIFF
--- a/migrations/000029_user_data_usage_fix.down.sql
+++ b/migrations/000029_user_data_usage_fix.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DROP TRIGGER IF EXISTS user_data_usage_last_modified_trigger ON cpu_usage_events CASCADE;
+DROP TRIGGER IF EXISTS user_data_usage_last_modified_trigger ON user_data_usage CASCADE;
+
+COMMIT;

--- a/migrations/000029_user_data_usage_fix.up.sql
+++ b/migrations/000029_user_data_usage_fix.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DROP TRIGGER IF EXISTS user_data_usage_last_modified_trigger ON user_data_usage CASCADE;
+DROP TRIGGER IF EXISTS user_data_usage_last_modified_trigger ON cpu_usage_totals CASCADE;
+CREATE TRIGGER user_data_usage_last_modified_trigger
+    BEFORE UPDATE ON user_data_usage
+    FOR EACH ROW
+    EXECUTE PROCEDURE moddatetime (last_modified);
+
+COMMIT;


### PR DESCRIPTION
Thanks @johnworth for catching this. I have the 'down' migration just drop both triggers if they exist, because if the user_data_usage one is on the cpu_usage_totals table it's not doing anything useful anyway.