### PR TITLE
Begin work getting de-database to deploy like our other deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-FROM busybox
+FROM migrate/migrate:4 AS migrate
+
+FROM postgres:12
 
 COPY migrations /migrations
 
+COPY --from=migrate /usr/local/bin/migrate /usr/local/bin/migrate
+
 VOLUME /migrations
+
+ENTRYPOINT ["migrate"]
+CMD ["--help"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,7 @@
 #!groovy
 
-timestamps {
-    node('docker') {
-        checkout scm
-        
-        docker.withRegistry('https://harbor.cyverse.org', 'jenkins-harbor-credentials') {
-
-            // Build and push the Docker image.
-            stage('Build Docker Image') {
-                dockerImage = docker.build("harbor.cyverse.org/de/de-database:${env.BUILD_TAG}")
-                dockerImage.push();
-                dockerImage.push('dev');
-            }
-        }
-    }
+stage('Trigger Build') {
+        build job: 'Build-Tag-Push-Deploy-QA', wait: true, parameters: [
+            [$class: 'StringParameterValue', name: 'PROJECT', value: 'de-database']
+        ]
 }

--- a/k8s/migrate-de-db.yml
+++ b/k8s/migrate-de-db.yml
@@ -9,6 +9,8 @@ spec:
       name: migrate-de-db
     spec:
       restartPolicy: Never
+      parallelism: 1
+      completions: 1
       containers:
       - name: update-de-db
         image: harbor.cyverse.org/de/de-database

--- a/k8s/migrate-de-db.yml
+++ b/k8s/migrate-de-db.yml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-de-db
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      name: migrate-de-db
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: update-de-db
+        image: harbor.cyverse.org/de/de-database
+        imagePullPolicy: Always
+        env:
+          - name: DE_DATABASE_URI
+            valueFrom:
+              secretKeyRef:
+                name: configs
+                key: DE_DATABASE_URI
+        args: ["-database", "$(DE_DATABASE_URI)", "-path", "/migrations", "up"]
+        volumeMounts:
+          - name: localtime
+            mountPath: /etc/localtime
+            readOnly: true
+          - name: timezone
+            mountPath: /etc/timezone
+            subPath: timezone
+      volumes:
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: timezone
+          configMap:
+            name: timezone
+            items:
+              - key: timezone
+                path: timezone

--- a/k8s/migrate-de-db.yml
+++ b/k8s/migrate-de-db.yml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: migrate-de-db
 spec:
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: 259200 
   template:
     metadata:
       name: migrate-de-db

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1
+kind: Config
+metadata:
+  name: migrate-de-db
+deploy:
+  kubectl:
+    manifests:
+      - k8s/migrate-de-db.yml
+build:
+  tagPolicy:
+    gitCommit: {}
+  artifacts:
+  - image: harbor.cyverse.org/de/de-database
+  local: {}


### PR DESCRIPTION
This should allow us to deploy changes to the database with K8s Jobs rather than with our current Ansible playbooks.

The Job will stick around for a day on completion, allowing us to take a look at logs.

The image that's built also contains the psql command, just in case we need it later.