### PR TITLE
CORE-1906: automatically delete job steps when the corresponding job …

### DIFF
--- a/migrations/000036_job_steps_fkey.down.sql
+++ b/migrations/000036_job_steps_fkey.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Remove the foreign key if it already exists.
+--
+ALTER TABLE IF EXISTS job_steps
+    DROP CONSTRAINT job_steps_job_id_fkey;
+
+--
+-- Add the foreign key back to the table without the cascade.
+--
+ALTER TABLE IF EXISTS job_steps
+    ADD CONSTRAINT job_steps_job_id_fkey
+    FOREIGN KEY (job_id)
+    REFERENCES jobs (id);
+
+COMMIT;

--- a/migrations/000036_job_steps_fkey.up.sql
+++ b/migrations/000036_job_steps_fkey.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Remove the foreign key if it already exists.
+--
+ALTER TABLE IF EXISTS job_steps
+DROP CONSTRAINT job_steps_job_id_fkey;
+
+--
+-- Add the foreign key back to the table with the cascade.
+--
+ALTER TABLE IF EXISTS job_steps
+ADD CONSTRAINT job_steps_job_id_fkey
+FOREIGN KEY (job_id)
+REFERENCES jobs (id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
…is deleted

Updating this constraint makes it easier to clean up the DE database if necessary. This might come up when we get a request to remove user information from the DE database or if a DE admin wants to remove deleted apps that are polluting the admin app list.
