### PR TITLE
fixed a regular expression escape character in 000004_basic_job_syste…

### DIFF
--- a/migrations/000004_basic_job_system.up.sql
+++ b/migrations/000004_basic_job_system.up.sql
@@ -7,8 +7,8 @@ SET search_path = public, pg_catalog;
 --
 CREATE TABLE IF NOT EXISTS integration_data (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
-    integrator_name character varying(255) NOT NULL CHECK (integrator_name ~ '\S'),
-    integrator_email character varying(255) NOT NULL CHECK (integrator_email ~ '\S'),
+    integrator_name character varying(255) NOT NULL CHECK (integrator_name ~ '\\S'),
+    integrator_email character varying(255) NOT NULL CHECK (integrator_email ~ '\\S'),
     user_id uuid,
     UNIQUE (integrator_name, integrator_email),
     FOREIGN KEY (user_id) REFERENCES users (id),


### PR DESCRIPTION
…m.up.sql

This was preventing migrations from working because the regular expression that it was checking against was simply `S`. This failed later because values that were being inserted into the `integration_data` table didn't contain an `S`.
