### PR TITLE
Change the periodic_warning_period to an interval

### DIFF
--- a/migrations/000039_notif_statuses_vice_periodic_interval.down.sql
+++ b/migrations/000039_notif_statuses_vice_periodic_interval.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY notif_statuses ALTER COLUMN periodic_warning_period TYPE integer USING NULL;
+
+COMMIT;

--- a/migrations/000039_notif_statuses_vice_periodic_interval.up.sql
+++ b/migrations/000039_notif_statuses_vice_periodic_interval.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY notif_statuses ALTER COLUMN periodic_warning_period TYPE interval USING CASE WHEN periodic_warning_period IS NULL THEN NULL ELSE (periodic_warning_period::text || ' seconds'::text)::interval END;
+
+COMMIT;


### PR DESCRIPTION
Following @slr71 's comments on https://github.com/cyverse-de/timelord/pull/10, this is probably going to be cleaner to handle them this way. The migration won't do much in practice (other than changing the type, obviously) but I figured I'd make it as functional as I could anyway.