### PR TITLE
CORE-1955 Add migration for deferrable app version order constraint

### DIFF
--- a/migrations/000040_app_versions_deferred_constraints.down.sql
+++ b/migrations/000040_app_versions_deferred_constraints.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY app_versions
+    DROP CONSTRAINT IF EXISTS app_versions_app_id_version_order_key;
+
+ALTER TABLE ONLY app_versions
+    ADD CONSTRAINT app_versions_app_id_version_order_key
+    UNIQUE (app_id, version_order);
+
+COMMIT;

--- a/migrations/000040_app_versions_deferred_constraints.up.sql
+++ b/migrations/000040_app_versions_deferred_constraints.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY app_versions
+    DROP CONSTRAINT IF EXISTS app_versions_app_id_version_order_key;
+
+-- Make the version_order unique constraint deferrable 
+-- so that the order can be updated in a transaction.
+ALTER TABLE ONLY app_versions
+    ADD CONSTRAINT app_versions_app_id_version_order_key
+    UNIQUE (app_id, version_order) DEFERRABLE INITIALLY DEFERRED;
+
+COMMIT;


### PR DESCRIPTION
This PR will add a migration that makes the app version order unique constraint deferrable so that the order can be updated in a transaction.