### PR TITLE
add migrations to replace user agent with session id column in logins table

### DIFF
--- a/migrations/000041_logins_keycloak_update.down.sql
+++ b/migrations/000041_logins_keycloak_update.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY logins
+  DROP COLUMN IF EXISTS session_id,
+  ADD COLUMN IF NOT EXISTS user_agent text; 
+
+COMMIT;

--- a/migrations/000041_logins_keycloak_update.up.sql
+++ b/migrations/000041_logins_keycloak_update.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY logins
+ DROP COLUMN IF EXISTS user_agent,
+  ADD COLUMN IF NOT EXISTS session_id uuid;
+
+COMMIT;


### PR DESCRIPTION
apps changes not started. terrain changes started at cyverse-de/terrain#292 -- starting from both ends and working to the middle on this apparently