### PR TITLE
Add a migration to add a 'usage_last_update' column to the jobs table

### DIFF
--- a/migrations/000043_job_usage_last_update.down.sql
+++ b/migrations/000043_job_usage_last_update.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS ONLY jobs
+    DROP IF EXISTS usage_last_update CASCADE;
+
+COMMIT;

--- a/migrations/000043_job_usage_last_update.up.sql
+++ b/migrations/000043_job_usage_last_update.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS ONLY jobs 
+    ADD IF NOT EXISTS usage_last_update timestamp without time zone;
+
+COMMIT;


### PR DESCRIPTION
(to be used for tracking when the most recent update was sent to QMS, in avoidance of double-counting)

This is in advance of resource-usage-api work integrating both this and the metadata field being added to QMS in https://github.com/cyverse/qms/pull/67