### PR TITLE
Support for S3 bucket tracking.

### DIFF
--- a/migrations/000045_buckets.down.sql
+++ b/migrations/000045_buckets.down.sql
@@ -3,6 +3,7 @@ BEGIN;
 SET search_path = public, pg_catalog;
 
 -- Drop tables in reverse dependency order
+DROP TABLE IF EXISTS job_buckets;
 DROP TABLE IF EXISTS bucket_permissions;
 DROP TABLE IF EXISTS buckets;
 

--- a/migrations/000045_buckets.down.sql
+++ b/migrations/000045_buckets.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+-- Drop tables in reverse dependency order
+DROP TABLE IF EXISTS bucket_permissions;
+DROP TABLE IF EXISTS buckets;
+
+-- Drop custom types
+DROP TYPE IF EXISTS bucket_permission_level;
+
+COMMIT;

--- a/migrations/000045_buckets.up.sql
+++ b/migrations/000045_buckets.up.sql
@@ -72,4 +72,25 @@ COMMENT ON COLUMN bucket_permissions.user_id IS 'User receiving access';
 COMMENT ON COLUMN bucket_permissions.permission_level IS 'Level of access granted (read, write, admin)';
 COMMENT ON COLUMN bucket_permissions.created_by IS 'User who granted this permission';
 
+--
+-- Job buckets table - tracks bucket usage in analyses/jobs
+--
+CREATE TABLE IF NOT EXISTS job_buckets (
+    job_id uuid NOT NULL,
+    bucket_id uuid NOT NULL,
+    mountpoint_path text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT now(),
+    PRIMARY KEY (job_id, bucket_id),
+    FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+    FOREIGN KEY (bucket_id) REFERENCES buckets(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_job_buckets_job_id ON job_buckets(job_id);
+CREATE INDEX idx_job_buckets_bucket_id ON job_buckets(bucket_id);
+
+COMMENT ON TABLE job_buckets IS 'Tracks which S3 buckets were used with which analyses (jobs)';
+COMMENT ON COLUMN job_buckets.job_id IS 'The analysis/job that used this bucket';
+COMMENT ON COLUMN job_buckets.bucket_id IS 'The bucket that was used in the analysis';
+COMMENT ON COLUMN job_buckets.mountpoint_path IS 'Path where the bucket was mounted inside the pod/container';
+
 COMMIT;

--- a/migrations/000045_buckets.up.sql
+++ b/migrations/000045_buckets.up.sql
@@ -54,11 +54,11 @@ CREATE TABLE IF NOT EXISTS bucket_permissions (
     user_id uuid NOT NULL,
     permission_level bucket_permission_level NOT NULL,
     created_at timestamp NOT NULL DEFAULT now(),
-    created_by uuid NOT NULL,
+    created_by uuid,
     PRIMARY KEY (id),
     FOREIGN KEY (bucket_id) REFERENCES buckets(id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (created_by) REFERENCES users(id),
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
     CONSTRAINT unique_bucket_user_permission UNIQUE (bucket_id, user_id)
 );
 

--- a/migrations/000045_buckets.up.sql
+++ b/migrations/000045_buckets.up.sql
@@ -1,0 +1,75 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- S3 Buckets table - tracks buckets managed by the Discovery Environment
+--
+CREATE TABLE IF NOT EXISTS buckets (
+    id uuid NOT NULL DEFAULT uuid_generate_v1(),
+    name text NOT NULL UNIQUE,
+    user_id uuid NOT NULL,
+    endpoint_url text NOT NULL,
+    region text,
+    description text,
+    deleted boolean NOT NULL DEFAULT false,
+    created_at timestamp NOT NULL DEFAULT now(),
+    modified_at timestamp NOT NULL DEFAULT now(),
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_buckets_name ON buckets(name);
+CREATE INDEX idx_buckets_user_id ON buckets(user_id);
+CREATE INDEX idx_buckets_deleted ON buckets(deleted);
+
+COMMENT ON TABLE buckets IS 'S3 buckets managed by the Discovery Environment on behalf of users';
+COMMENT ON COLUMN buckets.name IS 'S3 bucket name (globally unique)';
+COMMENT ON COLUMN buckets.user_id IS 'DE user who owns this bucket';
+COMMENT ON COLUMN buckets.endpoint_url IS 'S3 service endpoint URL';
+COMMENT ON COLUMN buckets.region IS 'S3 region where bucket is located';
+COMMENT ON COLUMN buckets.deleted IS 'Soft delete flag';
+
+--
+-- Bucket permission levels
+--
+DO $$
+BEGIN
+    CREATE TYPE bucket_permission_level AS ENUM (
+        'read',
+        'write',
+        'admin'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN
+        RAISE NOTICE 'bucket_permission_level type already exists, moving on';
+END$$;
+
+--
+-- Bucket permissions table - tracks user access to buckets
+--
+CREATE TABLE IF NOT EXISTS bucket_permissions (
+    id uuid NOT NULL DEFAULT uuid_generate_v1(),
+    bucket_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    permission_level bucket_permission_level NOT NULL,
+    created_at timestamp NOT NULL DEFAULT now(),
+    created_by uuid NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (bucket_id) REFERENCES buckets(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    CONSTRAINT unique_bucket_user_permission UNIQUE (bucket_id, user_id)
+);
+
+CREATE INDEX idx_bucket_permissions_bucket_id ON bucket_permissions(bucket_id);
+CREATE INDEX idx_bucket_permissions_user_id ON bucket_permissions(user_id);
+CREATE INDEX idx_bucket_permissions_permission_level ON bucket_permissions(permission_level);
+
+COMMENT ON TABLE bucket_permissions IS 'Access permissions for shared S3 buckets';
+COMMENT ON COLUMN bucket_permissions.bucket_id IS 'The bucket being shared';
+COMMENT ON COLUMN bucket_permissions.user_id IS 'User receiving access';
+COMMENT ON COLUMN bucket_permissions.permission_level IS 'Level of access granted (read, write, admin)';
+COMMENT ON COLUMN bucket_permissions.created_by IS 'User who granted this permission';
+
+COMMIT;

--- a/migrations/000045_buckets.up.sql
+++ b/migrations/000045_buckets.up.sql
@@ -7,10 +7,10 @@ SET search_path = public, pg_catalog;
 --
 CREATE TABLE IF NOT EXISTS buckets (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
-    name text NOT NULL UNIQUE,
+    name text NOT NULL,
     user_id uuid NOT NULL,
     endpoint_url text NOT NULL,
-    region text,
+    region text NOT NULL,
     description text,
     deleted boolean NOT NULL DEFAULT false,
     created_at timestamp NOT NULL DEFAULT now(),
@@ -19,9 +19,9 @@ CREATE TABLE IF NOT EXISTS buckets (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_buckets_name ON buckets(name);
-CREATE INDEX idx_buckets_user_id ON buckets(user_id);
-CREATE INDEX idx_buckets_deleted ON buckets(deleted);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_buckets_name ON buckets(name);
+CREATE INDEX IF NOT EXISTS idx_buckets_user_id ON buckets(user_id);
+CREATE INDEX IF NOT EXISTS idx_buckets_deleted ON buckets(deleted);
 
 COMMENT ON TABLE buckets IS 'S3 buckets managed by the Discovery Environment on behalf of users';
 COMMENT ON COLUMN buckets.name IS 'S3 bucket name (globally unique)';
@@ -58,13 +58,13 @@ CREATE TABLE IF NOT EXISTS bucket_permissions (
     PRIMARY KEY (id),
     FOREIGN KEY (bucket_id) REFERENCES buckets(id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
-    CONSTRAINT unique_bucket_user_permission UNIQUE (bucket_id, user_id)
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
 );
 
-CREATE INDEX idx_bucket_permissions_bucket_id ON bucket_permissions(bucket_id);
-CREATE INDEX idx_bucket_permissions_user_id ON bucket_permissions(user_id);
-CREATE INDEX idx_bucket_permissions_permission_level ON bucket_permissions(permission_level);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_bucket_permissions_bucket_user ON bucket_permissions(bucket_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_bucket_permissions_bucket_id ON bucket_permissions(bucket_id);
+CREATE INDEX IF NOT EXISTS idx_bucket_permissions_user_id ON bucket_permissions(user_id);
+CREATE INDEX IF NOT EXISTS idx_bucket_permissions_permission_level ON bucket_permissions(permission_level);
 
 COMMENT ON TABLE bucket_permissions IS 'Access permissions for shared S3 buckets';
 COMMENT ON COLUMN bucket_permissions.bucket_id IS 'The bucket being shared';
@@ -85,8 +85,8 @@ CREATE TABLE IF NOT EXISTS job_buckets (
     FOREIGN KEY (bucket_id) REFERENCES buckets(id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_job_buckets_job_id ON job_buckets(job_id);
-CREATE INDEX idx_job_buckets_bucket_id ON job_buckets(bucket_id);
+CREATE INDEX IF NOT EXISTS idx_job_buckets_job_id ON job_buckets(job_id);
+CREATE INDEX IF NOT EXISTS idx_job_buckets_bucket_id ON job_buckets(bucket_id);
 
 COMMENT ON TABLE job_buckets IS 'Tracks which S3 buckets were used with which analyses (jobs)';
 COMMENT ON COLUMN job_buckets.job_id IS 'The analysis/job that used this bucket';


### PR DESCRIPTION
##  Summary
  Added tracking for S3 bucket usage in analyses.

## Changes
* Added migration 000045 migration that adds tables for buckets, bucket_permissions, and job_buckets.
* The buckets table tracks the buckets created by the Discovery Environment. It does not contain auth information.
* The bucket_permissions table tracks a users permissions on a bucket. This is intended to allow sharing buckets along with analyses.
* The job_buckets table associates one or more buckets with each job. A bucket can be used in more than one job.
* The job_buckets table also tracks the mountpoint for the bucket in the analysis.
* Added down migrations as well.