### PR TITLE
Add a migration that tracks the association between tools and acceptable GPU models

### DIFF
--- a/migrations/000046_tool_gpu_models.down.sql
+++ b/migrations/000046_tool_gpu_models.down.sql
@@ -2,6 +2,6 @@ BEGIN;
 
 SET search_path = public, pg_catalog;
 
-DROP TABLE IF EXISTS tool_gpu_models CASCADE;
+DROP TABLE IF EXISTS container_gpu_models CASCADE;
 
 COMMIT;

--- a/migrations/000046_tool_gpu_models.down.sql
+++ b/migrations/000046_tool_gpu_models.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DROP TABLE IF EXISTS tool_gpu_models CASCADE;
+
+COMMIT;

--- a/migrations/000046_tool_gpu_models.up.sql
+++ b/migrations/000046_tool_gpu_models.up.sql
@@ -2,18 +2,18 @@ BEGIN;
 
 SET search_path = public, pg_catalog;
 
--- tool_gpu_models
--- Associates tools with GPU models they are able to use
-CREATE TABLE IF NOT EXISTS tool_gpu_models (
-  -- Foreign key into the tools table
-  tool_id uuid NOT NULL,
+-- container_gpu_models
+-- Associates tools (via container settings) with GPU models they are able to use
+CREATE TABLE IF NOT EXISTS container_gpu_models (
+  -- Foreign key into the container_settings table
+  container_settings_id uuid NOT NULL,
 
   -- The name of the GPU model (e.g., "NVIDIA-A16")
   -- Allowed values are managed by configuration outside of this database.
   gpu_model text NOT NULL,
 
-  FOREIGN KEY (tool_id) REFERENCES tools(id) ON DELETE CASCADE,
-  PRIMARY KEY (tool_id, gpu_model)
+  FOREIGN KEY (container_settings_id) REFERENCES container_settings(id) ON DELETE CASCADE,
+  PRIMARY KEY (container_settings_id, gpu_model)
 );
 
 COMMIT;

--- a/migrations/000046_tool_gpu_models.up.sql
+++ b/migrations/000046_tool_gpu_models.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+-- tool_gpu_models
+-- Associates tools with GPU models they are able to use
+CREATE TABLE IF NOT EXISTS tool_gpu_models (
+  -- Foreign key into the tools table
+  tool_id uuid NOT NULL,
+
+  -- The name of the GPU model (e.g., "NVIDIA-A16")
+  -- Allowed values are managed by configuration outside of this database.
+  gpu_model text NOT NULL,
+
+  FOREIGN KEY (tool_id) REFERENCES tools(id) ON DELETE CASCADE,
+  PRIMARY KEY (tool_id, gpu_model)
+);
+
+COMMIT;


### PR DESCRIPTION
Pretty straightforward, I think. Most of the management of allowed values and things is at a higher level, so this is really just about storing the association.