### PR TITLE
Add operators.base_url and expose operator_id in job_listings

### DIFF
--- a/migrations/000050_operators_base_url.down.sql
+++ b/migrations/000050_operators_base_url.down.sql
@@ -3,9 +3,10 @@ BEGIN;
 SET search_path = public, pg_catalog;
 
 --
--- Restore the job listing view without operator_id. CREATE OR REPLACE cannot
--- drop a column, so the view is dropped and recreated. Nothing else depends
--- on job_listings, so no CASCADE is needed.
+-- Restore the job listing view without the operators left-join or the
+-- operator_base_url column. CREATE OR REPLACE cannot drop a column, so the
+-- view is dropped and recreated. Nothing else depends on job_listings, so no
+-- CASCADE is needed.
 --
 -- The is_batch subquery uses SELECT 1 rather than SELECT * so the recreated
 -- view does not capture a frozen dependency on jobs.operator_id (which still

--- a/migrations/000050_operators_base_url.down.sql
+++ b/migrations/000050_operators_base_url.down.sql
@@ -7,6 +7,11 @@ SET search_path = public, pg_catalog;
 -- drop a column, so the view is dropped and recreated. Nothing else depends
 -- on job_listings, so no CASCADE is needed.
 --
+-- The is_batch subquery uses SELECT 1 rather than SELECT * so the recreated
+-- view does not capture a frozen dependency on jobs.operator_id (which still
+-- exists at this point). A SELECT * here would expand to include operator_id
+-- and block migration 000048's down step from dropping that column.
+--
 DROP VIEW IF EXISTS job_listings;
 
 CREATE VIEW job_listings AS
@@ -29,7 +34,7 @@ CREATE VIEW job_listings AS
            t.name AS job_type,
            j.parent_id,
            EXISTS (
-               SELECT * FROM jobs child
+               SELECT 1 FROM jobs child
                WHERE child.parent_id = j.id
            ) AS is_batch,
            t.system_id,

--- a/migrations/000050_operators_base_url.down.sql
+++ b/migrations/000050_operators_base_url.down.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Restore the job listing view without operator_id. CREATE OR REPLACE cannot
+-- drop a column, so the view is dropped and recreated. Nothing else depends
+-- on job_listings, so no CASCADE is needed.
+--
+DROP VIEW IF EXISTS job_listings;
+
+CREATE VIEW job_listings AS
+    SELECT j.id,
+           j.job_name,
+           j.app_name,
+           j.start_date,
+           j.end_date,
+           j.status,
+           j.deleted,
+           j.notify,
+           u.username,
+           j.job_description,
+           j.app_id,
+           j.app_version_id,
+           j.app_wiki_url,
+           j.app_description,
+           j.result_folder_path,
+           j.submission,
+           t.name AS job_type,
+           j.parent_id,
+           EXISTS (
+               SELECT * FROM jobs child
+               WHERE child.parent_id = j.id
+           ) AS is_batch,
+           t.system_id,
+           j.planned_end_date,
+           j.user_id
+    FROM jobs j
+    JOIN users u ON j.user_id = u.id
+    JOIN job_types t ON j.job_type_id = t.id;
+
+ALTER TABLE IF EXISTS ONLY operators
+    DROP COLUMN IF EXISTS base_url;
+
+COMMIT;

--- a/migrations/000050_operators_base_url.up.sql
+++ b/migrations/000050_operators_base_url.up.sql
@@ -17,6 +17,12 @@ ALTER TABLE IF EXISTS ONLY operators
 -- to the operators table and resolve the per-operator base URL. operator_id
 -- is appended at the end of the select list so CREATE OR REPLACE is valid.
 --
+-- The is_batch subquery uses SELECT 1 rather than SELECT * so the view does
+-- not capture a frozen dependency on every column of jobs. SELECT * would
+-- expand to the jobs column list as it stands at view-creation time, which
+-- would make this view block an unrelated DROP COLUMN on jobs later (e.g.
+-- rolling back the operator_id column in migration 000048).
+--
 CREATE OR REPLACE VIEW job_listings AS
     SELECT j.id,
            j.job_name,
@@ -37,7 +43,7 @@ CREATE OR REPLACE VIEW job_listings AS
            t.name AS job_type,
            j.parent_id,
            EXISTS (
-               SELECT * FROM jobs child
+               SELECT 1 FROM jobs child
                WHERE child.parent_id = j.id
            ) AS is_batch,
            t.system_id,

--- a/migrations/000050_operators_base_url.up.sql
+++ b/migrations/000050_operators_base_url.up.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- The base URL of the VICE landing/loading domain for analyses launched on
+-- this operator (e.g. https://sandbox.cyverse.rocks). Nullable: pre-existing
+-- rows have no value and consumers fall back to a static default. New
+-- operators are required to supply one at creation time.
+--
+ALTER TABLE IF EXISTS ONLY operators
+    ADD COLUMN IF NOT EXISTS base_url text CHECK (base_url ~ '\S');
+
+--
+-- Recreate the job listing view to expose operator_id so consumers can join
+-- to the operators table and resolve the per-operator base URL. operator_id
+-- is appended at the end of the select list so CREATE OR REPLACE is valid.
+--
+CREATE OR REPLACE VIEW job_listings AS
+    SELECT j.id,
+           j.job_name,
+           j.app_name,
+           j.start_date,
+           j.end_date,
+           j.status,
+           j.deleted,
+           j.notify,
+           u.username,
+           j.job_description,
+           j.app_id,
+           j.app_version_id,
+           j.app_wiki_url,
+           j.app_description,
+           j.result_folder_path,
+           j.submission,
+           t.name AS job_type,
+           j.parent_id,
+           EXISTS (
+               SELECT * FROM jobs child
+               WHERE child.parent_id = j.id
+           ) AS is_batch,
+           t.system_id,
+           j.planned_end_date,
+           j.user_id,
+           j.operator_id
+    FROM jobs j
+    JOIN users u ON j.user_id = u.id
+    JOIN job_types t ON j.job_type_id = t.id;
+
+COMMIT;

--- a/migrations/000050_operators_base_url.up.sql
+++ b/migrations/000050_operators_base_url.up.sql
@@ -13,9 +13,12 @@ ALTER TABLE IF EXISTS ONLY operators
     ADD COLUMN IF NOT EXISTS base_url text CHECK (base_url ~ '\S');
 
 --
--- Recreate the job listing view to expose operator_id so consumers can join
--- to the operators table and resolve the per-operator base URL. operator_id
+-- Recreate the job listing view to left-join the operators table and expose
+-- operator_base_url, so consumers can resolve the per-operator VICE base URL
+-- directly from the view instead of joining operators themselves. The column
 -- is appended at the end of the select list so CREATE OR REPLACE is valid.
+-- The join is LEFT so jobs with no operator_id (legacy / non-VICE jobs) still
+-- appear, with a NULL operator_base_url.
 --
 -- The is_batch subquery uses SELECT 1 rather than SELECT * so the view does
 -- not capture a frozen dependency on every column of jobs. SELECT * would
@@ -49,9 +52,10 @@ CREATE OR REPLACE VIEW job_listings AS
            t.system_id,
            j.planned_end_date,
            j.user_id,
-           j.operator_id
+           o.base_url AS operator_base_url
     FROM jobs j
     JOIN users u ON j.user_id = u.id
-    JOIN job_types t ON j.job_type_id = t.id;
+    JOIN job_types t ON j.job_type_id = t.id
+    LEFT JOIN operators o ON o.id = j.operator_id;
 
 COMMIT;

--- a/migrations/000050_operators_base_url.up.sql
+++ b/migrations/000050_operators_base_url.up.sql
@@ -4,9 +4,10 @@ SET search_path = public, pg_catalog;
 
 --
 -- The base URL of the VICE landing/loading domain for analyses launched on
--- this operator (e.g. https://sandbox.cyverse.rocks). Nullable: pre-existing
--- rows have no value and consumers fall back to a static default. New
--- operators are required to supply one at creation time.
+-- this operator (e.g. https://sandbox.cyverse.rocks). Nullable at the schema
+-- level: pre-existing rows have no value and consumers fall back to a static
+-- default. app-exposer's admin API requires a value when creating a new
+-- operator, so NULL only occurs on legacy rows that predate this column.
 --
 ALTER TABLE IF EXISTS ONLY operators
     ADD COLUMN IF NOT EXISTS base_url text CHECK (base_url ~ '\S');


### PR DESCRIPTION
## Summary

- Adds a nullable `base_url` column to the `operators` table — the VICE landing-domain base URL (e.g. `https://sandbox.cyverse.rocks`) for analyses launched on that operator.
- Recreates the `job_listings` view to `LEFT JOIN operators` and expose `operator_base_url`, so consumers can resolve the per-operator VICE URL directly from the view without joining `operators` themselves.

## Context

VICE analyses can now be scheduled onto different Kubernetes clusters, each fronted by its own `vice-operator`. `apps` currently builds every interactive-app URL from a single static config value, so an analysis launched on a non-default cluster links the user to the wrong domain. This migration provides the data `apps` needs to build the correct per-cluster URL.

`base_url` is nullable: pre-existing rows have no value and consumers fall back to the static default. The `operators` join is `LEFT`, so jobs with no `operator_id` (legacy / non-VICE) still appear with a NULL `operator_base_url`. The NOTIFY triggers from migration 000049 are intentionally left untouched — `base_url` is consumed only by `apps`, not by app-exposer's scheduler.

Note: the view's `is_batch` subquery was changed from `EXISTS (SELECT * ...)` to `EXISTS (SELECT 1 ...)`. `SELECT *` would freeze a dependency on every `jobs` column at view-creation time (including `operator_id`), which would block migration 000048's down step from dropping that column on rollback.

Part of a 3-repo change (de-database, app-exposer, apps) on the `operator-base-url` branch.

## Test plan

- [x] `migrate up` then `migrate down` round-trip on a real DB, including the force/down/up/down sequence that previously failed
- [x] `\d operators` shows `base_url`; `\d+ job_listings` shows `operator_base_url`
- [x] down migration cleanly reverts both

🤖 Generated with [Claude Code](https://claude.com/claude-code)