### PR TITLE
CORE-2156: fix a regex escaping problem

### DIFF
--- a/migrations/000004_basic_job_system.up.sql
+++ b/migrations/000004_basic_job_system.up.sql
@@ -7,8 +7,8 @@ SET search_path = public, pg_catalog;
 --
 CREATE TABLE IF NOT EXISTS integration_data (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
-    integrator_name character varying(255) NOT NULL CHECK (integrator_name ~ '\S'),
-    integrator_email character varying(255) NOT NULL CHECK (integrator_email ~ '\S'),
+    integrator_name character varying(255) NOT NULL CHECK (integrator_name ~ '[^[:space:]]'),
+    integrator_email character varying(255) NOT NULL CHECK (integrator_email ~ '[^[:space:]]'),
     user_id uuid,
     UNIQUE (integrator_name, integrator_email),
     FOREIGN KEY (user_id) REFERENCES users (id),


### PR DESCRIPTION
This change switches from the Perl-style character class `\S` to the POSIX style character class `[^[:space:]]` in order to avoid problems with escaping. We've had varying issues with this in the past, so we're switching to POSIX character classes in an attempt to get some consistent behavior.