### PR TITLE
Add migrations for new operators fields

### DIFF
--- a/migrations/000051_operators_deactivation.down.sql
+++ b/migrations/000051_operators_deactivation.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Restore the update trigger to its original scheduling-column list before
+-- dropping the columns it would otherwise reference.
+--
+DROP TRIGGER IF EXISTS trigger_operators_notify_update ON operators;
+CREATE TRIGGER trigger_operators_notify_update
+    AFTER UPDATE OF name, url, tls_skip_verify, priority ON operators
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_operators_changed();
+
+ALTER TABLE IF EXISTS ONLY operators
+    DROP COLUMN IF EXISTS deactivated,
+    DROP COLUMN IF EXISTS accepting_launches;
+
+COMMIT;

--- a/migrations/000051_operators_deactivation.up.sql
+++ b/migrations/000051_operators_deactivation.up.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- accepting_launches is a graceful drain switch: when false, app-exposer routes
+-- no new launches to the operator, but it stays in service otherwise (still
+-- reconciled, existing analyses remain listable/searchable/quota-counted).
+--
+ALTER TABLE IF EXISTS ONLY operators
+    ADD COLUMN IF NOT EXISTS accepting_launches boolean NOT NULL DEFAULT true;
+
+--
+-- deactivated is a full kill switch: when true, the operator drops out of the
+-- live scheduler pool entirely (no launches, reconciliation bypassed, removed
+-- from listing/search/quota fan-out). It takes precedence over
+-- accepting_launches.
+--
+ALTER TABLE IF EXISTS ONLY operators
+    ADD COLUMN IF NOT EXISTS deactivated boolean NOT NULL DEFAULT false;
+
+--
+-- accepting_launches and deactivated are scheduling-relevant, so changes must
+-- notify listeners immediately (rather than waiting for the periodic poll).
+-- Recreate the per-row update trigger with the two new columns added to its
+-- column list. Reuse the existing notify_operators_changed() function.
+--
+DROP TRIGGER IF EXISTS trigger_operators_notify_update ON operators;
+CREATE TRIGGER trigger_operators_notify_update
+    AFTER UPDATE OF name, url, tls_skip_verify, priority, accepting_launches, deactivated ON operators
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_operators_changed();
+
+COMMIT;


### PR DESCRIPTION
Adds the `operators.deactivated` and `operators.accepting_launches` columns, along with modifications to the notification trigger.

This is part of the work to allow us to disable launches to an operator and to completely deactivate an operator.