### PR TITLE
Make migration regexes immune to standard_conforming_strings=off

### DIFF
--- a/migrations/000021_permissions_db.up.sql
+++ b/migrations/000021_permissions_db.up.sql
@@ -16,7 +16,7 @@ BEGIN;
     -- Uniqueness constraint on the resource type name.
     --
     CREATE UNIQUE INDEX IF NOT EXISTS resource_types_name_unique
-        ON resource_types (lower(trim(regexp_replace(name, '\s+', ' ', 'g'))));
+        ON resource_types (lower(trim(regexp_replace(name, '[[:space:]]+', ' ', 'g'))));
 
     --
     -- Table for storing specific resources to which permissions may be applied.

--- a/migrations/000048_operators_table.up.sql
+++ b/migrations/000048_operators_table.up.sql
@@ -9,8 +9,8 @@ SET search_path = public, pg_catalog;
 --
 CREATE TABLE IF NOT EXISTS operators (
     id uuid NOT NULL DEFAULT uuid_generate_v1(),
-    name text NOT NULL UNIQUE CHECK (name ~ '\S'),
-    url text NOT NULL UNIQUE CHECK (url ~ '\S'),
+    name text NOT NULL UNIQUE CHECK (name ~ '[^[:space:]]'),
+    url text NOT NULL UNIQUE CHECK (url ~ '[^[:space:]]'),
     -- When true, skip TLS certificate verification for this operator's endpoint.
     tls_skip_verify boolean NOT NULL DEFAULT false,
     -- Explicit scheduling priority; lower values are tried first.

--- a/migrations/000050_operators_base_url.up.sql
+++ b/migrations/000050_operators_base_url.up.sql
@@ -10,7 +10,7 @@ SET search_path = public, pg_catalog;
 -- operator, so NULL only occurs on legacy rows that predate this column.
 --
 ALTER TABLE IF EXISTS ONLY operators
-    ADD COLUMN IF NOT EXISTS base_url text CHECK (base_url ~ '\S');
+    ADD COLUMN IF NOT EXISTS base_url text CHECK (base_url ~ '[^[:space:]]');
 
 --
 -- Recreate the job listing view to left-join the operators table and expose

--- a/migrations/000053_fix_escape_mangled_regexes.down.sql
+++ b/migrations/000053_fix_escape_mangled_regexes.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+--
+-- Intentionally a no-op. The up migration repairs definitions that earlier
+-- migrations (000021, 000048, 000050) always intended to create, and those
+-- source migrations now produce the corrected definitions directly — so the
+-- state after reverting this migration is identical to the state after
+-- applying it. Restoring the escape-mangled definitions would reintroduce
+-- the bug and is never desirable.
+--
+
+COMMIT;

--- a/migrations/000053_fix_escape_mangled_regexes.up.sql
+++ b/migrations/000053_fix_escape_mangled_regexes.up.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Migrations 000021, 000048, and 000050 originally wrote their regexes with
+-- backslash escapes ('\s+', '\S'). On servers running with
+-- standard_conforming_strings = off, those literals were escape-processed
+-- before parsing, so the stored definitions lost the backslash: the operators
+-- checks became "must contain a capital S" (name ~ 'S') and the permissions
+-- name index collapsed runs of the letter "s" instead of whitespace. The
+-- source migrations now use bracket expressions, which contain no backslash
+-- and parse identically under either setting; this migration rebuilds the
+-- affected definitions on databases that already ran the mangled versions.
+-- On databases whose definitions are already correct, the rebuild is a no-op
+-- re-creation of identical constraints and index.
+--
+ALTER TABLE IF EXISTS ONLY operators
+    DROP CONSTRAINT IF EXISTS operators_name_check,
+    DROP CONSTRAINT IF EXISTS operators_url_check,
+    DROP CONSTRAINT IF EXISTS operators_base_url_check,
+    ADD CONSTRAINT operators_name_check CHECK (name ~ '[^[:space:]]'),
+    ADD CONSTRAINT operators_url_check CHECK (url ~ '[^[:space:]]'),
+    ADD CONSTRAINT operators_base_url_check CHECK (base_url ~ '[^[:space:]]');
+
+--
+-- Rebuilding the unique index re-validates existing rows: resource type
+-- names that differ only in whitespace runs would now collide and abort the
+-- migration, which is the intended uniqueness rule finally being enforced.
+--
+DROP INDEX IF EXISTS permissions.resource_types_name_unique;
+CREATE UNIQUE INDEX resource_types_name_unique
+    ON permissions.resource_types
+    (lower(trim(regexp_replace(name, '[[:space:]]+', ' ', 'g'))));
+
+COMMIT;


### PR DESCRIPTION
## Problem

Registering a VICE operator on sw-cacti fails with:

```
pq: new row for relation "operators" violates check constraint "operators_base_url_check"
```

The postgres server there runs with `standard_conforming_strings = off` (set in a legacy compat section of its config). Under that setting, the `'\S'` / `'\s+'` string literals in migrations 000021, 000048, and 000050 are escape-processed before parsing, so the stored definitions lose the backslash:

- `operators.name/url/base_url` checks became `~ 'S'` — literally "must contain a capital letter S". `prod`, `http://vice-operator.vice-apps:10000`, and `https://vice.swcacti.cyverse.org` all fail it.
- `permissions.resource_types_name_unique` normalizes with `regexp_replace(name, 's+', ' ', 'g')` — collapsing runs of the letter "s" instead of whitespace.

Any environment whose DB runs with that setting off gets the same mangled definitions on a fresh migrate.

## Fix

- Rewrite the regexes in 000021/000048/000050 as bracket expressions (`[^[:space:]]`, `[[:space:]]+`), which contain no backslash and parse identically under either setting.
- Add migration 000053 to rebuild the affected constraints and index on databases that already ran the mangled versions. On databases whose definitions are already correct, the rebuild re-creates identical definitions. The down migration is an intentional no-op: the corrected source migrations now produce the same definitions, so reverting must not reintroduce the mangled forms.

Note: rebuilding the unique index re-validates existing `resource_types` rows; names differing only in whitespace runs would now collide and abort the migration loudly — that is the intended uniqueness rule finally being enforced.

## Verification

Against a throwaway Postgres 16 started with `-c standard_conforming_strings=off`:

- All 53 migrations apply cleanly from scratch.
- `pg_constraint` shows `name ~ '[^[:space:]]'` etc., and the index uses `'[[:space:]]+'`.
- The previously failing insert (`prod` / `http://vice-operator.vice-apps:10000` / `https://vice.swcacti.cyverse.org`) succeeds.
- A whitespace-only `base_url` is still rejected by the check.
- Migration 000053 round-trips `down 1` / `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)