### PR TITLE
Add group storage to the permissions schema

### DIFF
--- a/migrations/000054_permissions_groups.down.sql
+++ b/migrations/000054_permissions_groups.down.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Drops all group data. Grouper remains the recoverable source of truth until it
+-- is decommissioned, which is why the Grouper import is a separate command
+-- rather than a migration.
+--
+
+DROP TRIGGER IF EXISTS trigger_groups_updated_at ON groups;
+DROP FUNCTION IF EXISTS update_groups_updated_at();
+
+DROP TRIGGER IF EXISTS trigger_groups_detach_before_delete ON groups;
+DROP FUNCTION IF EXISTS groups_detach_before_delete();
+DROP FUNCTION IF EXISTS recompute_group_closure(uuid[]);
+DROP FUNCTION IF EXISTS group_ancestors(uuid[]);
+
+DROP INDEX IF EXISTS group_effective_members_member_idx;
+DROP TABLE IF EXISTS group_effective_members;
+
+DROP INDEX IF EXISTS group_memberships_member_idx;
+DROP TABLE IF EXISTS group_memberships;
+
+DROP INDEX IF EXISTS groups_type_owner_name_idx;
+DROP INDEX IF EXISTS groups_identity_unique;
+DROP TABLE IF EXISTS groups;
+
+DROP TABLE IF EXISTS group_types;
+
+ALTER TABLE subjects DROP CONSTRAINT IF EXISTS subjects_id_subject_type_key;
+ALTER TABLE subjects ALTER COLUMN subject_id DROP DEFAULT;
+
+--
+-- Restores the original width. This fails rather than truncates if any subject
+-- identifier longer than 64 characters was created while the column was wide --
+-- silently discarding part of an identity is worse than refusing to roll back.
+--
+ALTER TABLE subjects ALTER COLUMN subject_id TYPE varchar(64);
+
+COMMIT;

--- a/migrations/000054_permissions_groups.down.sql
+++ b/migrations/000054_permissions_groups.down.sql
@@ -8,6 +8,10 @@ SET search_path = permissions, public, pg_catalog;
 -- rather than a migration.
 --
 
+DROP TRIGGER IF EXISTS trigger_group_data_source_changed_at ON group_data_source;
+DROP FUNCTION IF EXISTS update_group_data_source_changed_at();
+DROP TABLE IF EXISTS group_data_source;
+
 DROP TRIGGER IF EXISTS trigger_groups_updated_at ON groups;
 DROP FUNCTION IF EXISTS update_groups_updated_at();
 

--- a/migrations/000054_permissions_groups.down.sql
+++ b/migrations/000054_permissions_groups.down.sql
@@ -28,6 +28,11 @@ DROP TABLE IF EXISTS groups;
 
 DROP TABLE IF EXISTS group_types;
 
+DROP INDEX IF EXISTS subjects_user_id_unique;
+ALTER TABLE subjects DROP CONSTRAINT IF EXISTS subjects_user_id_is_user;
+ALTER TABLE subjects DROP CONSTRAINT IF EXISTS subjects_user_id_fkey;
+ALTER TABLE subjects DROP COLUMN IF EXISTS user_id;
+
 ALTER TABLE subjects DROP CONSTRAINT IF EXISTS subjects_id_subject_type_key;
 ALTER TABLE subjects ALTER COLUMN subject_id DROP DEFAULT;
 

--- a/migrations/000054_permissions_groups.up.sql
+++ b/migrations/000054_permissions_groups.up.sql
@@ -339,4 +339,59 @@ CREATE TRIGGER trigger_groups_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_groups_updated_at();
 
+--
+-- Which system owns group data. The Grouper importer reconciles -- it removes
+-- memberships and grants that Grouper no longer has -- which is correct only
+-- while Grouper is still authoritative. Run it once after cutover and it would
+-- delete whatever was created natively in the meantime.
+--
+-- The importer refuses to start unless this says 'grouper'. There is deliberately
+-- no override flag: the only way to run a destructive reconcile after cutover is
+-- to set this back, which is a deliberate write with attribution and a timestamp
+-- rather than something typed at the end of an argument list. Flipping it to
+-- 'native' is an ordered step of the cutover, performed before anything is
+-- pointed at the new store.
+--
+CREATE TABLE IF NOT EXISTS group_data_source (
+    -- Single row: the only permitted key is true, and the primary key makes it
+    -- unique, so a second row cannot be inserted.
+    id boolean NOT NULL DEFAULT true CHECK (id),
+    source varchar(16) NOT NULL CHECK (source IN ('grouper', 'native')),
+    changed_at timestamp with time zone NOT NULL DEFAULT now(),
+    -- Who performed the change. Free text: this is usually an operator, not a
+    -- subject or a DE user.
+    changed_by varchar(512) NOT NULL CHECK (changed_by ~ '[^[:space:]]'),
+    note text,
+    PRIMARY KEY (id)
+);
+
+COMMENT ON TABLE group_data_source IS
+    'Single row recording whether Grouper or this database is authoritative for group '
+    'data. The Grouper importer refuses to run a destructive reconcile unless it says '
+    'grouper; set it to native as part of cutover.';
+
+INSERT INTO group_data_source (source, changed_by, note)
+     VALUES ('grouper', 'migration 000054',
+             'Grouper remains authoritative until cutover.')
+ON CONFLICT DO NOTHING;
+
+--
+-- Keeps changed_at honest: the timestamp matters precisely because someone will
+-- want to know when the cutover happened, and an operator flipping source by
+-- hand would not think to set it.
+--
+CREATE OR REPLACE FUNCTION update_group_data_source_changed_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.changed_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_group_data_source_changed_at ON group_data_source;
+CREATE TRIGGER trigger_group_data_source_changed_at
+    BEFORE UPDATE ON group_data_source
+    FOR EACH ROW
+    EXECUTE FUNCTION update_group_data_source_changed_at();
+
 COMMIT;

--- a/migrations/000054_permissions_groups.up.sql
+++ b/migrations/000054_permissions_groups.up.sql
@@ -253,7 +253,11 @@ RETURNS SETOF uuid AS $$
          WHERE gm.member_type = 'group'
     )
     SELECT id FROM up;
-$$ LANGUAGE sql STABLE;
+$$ LANGUAGE sql STABLE
+-- Pinned so the function resolves the group tables no matter what the calling
+-- session's search_path is. Without this, deleting a group from any client that
+-- does not put this schema on its path fails inside the delete trigger.
+SET search_path = permissions, public, pg_catalog;
 
 COMMENT ON FUNCTION group_ancestors(uuid[]) IS
     'The given groups plus every group transitively containing them: the set to '
@@ -284,7 +288,8 @@ BEGIN
     )
     SELECT DISTINCT root, member_id FROM reachable WHERE member_type = 'user';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+SET search_path = permissions, public, pg_catalog;
 
 COMMENT ON FUNCTION recompute_group_closure(uuid[]) IS
     'Rebuilds the effective membership of the given groups from direct membership.';
@@ -316,7 +321,8 @@ BEGIN
 
     RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+SET search_path = permissions, public, pg_catalog;
 
 DROP TRIGGER IF EXISTS trigger_groups_detach_before_delete ON groups;
 CREATE TRIGGER trigger_groups_detach_before_delete
@@ -331,7 +337,8 @@ BEGIN
     NEW.updated_at = now();
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+SET search_path = permissions, public, pg_catalog;
 
 DROP TRIGGER IF EXISTS trigger_groups_updated_at ON groups;
 CREATE TRIGGER trigger_groups_updated_at
@@ -386,7 +393,8 @@ BEGIN
     NEW.changed_at = now();
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+SET search_path = permissions, public, pg_catalog;
 
 DROP TRIGGER IF EXISTS trigger_group_data_source_changed_at ON group_data_source;
 CREATE TRIGGER trigger_group_data_source_changed_at

--- a/migrations/000054_permissions_groups.up.sql
+++ b/migrations/000054_permissions_groups.up.sql
@@ -1,0 +1,293 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Group membership moves out of Grouper and into this schema so that expanding
+-- a subject to its groups becomes a join inside the permission lookup query
+-- rather than a call to another service.
+--
+
+--
+-- Subject identifiers are usernames for users and group identifiers for groups.
+-- 64 characters is too narrow for the longest usernames already in public.users,
+-- and group membership now requires every member to have a subject row.
+--
+ALTER TABLE subjects ALTER COLUMN subject_id TYPE varchar(512);
+
+--
+-- Groups imported from Grouper keep their original 32-hex identifiers so that
+-- existing permission grants and iRODS group names remain valid. Groups created
+-- from here on must be indistinguishable from them, so the default mints the
+-- same dashless form rather than a canonical uuid.
+--
+ALTER TABLE subjects
+    ALTER COLUMN subject_id SET DEFAULT replace(uuid_generate_v1()::text, '-', '');
+
+--
+-- Redundant with the primary key for uniqueness, but required as the target of
+-- the composite foreign keys below, which pin the subject type of a referencing
+-- row (a group's backing subject must be a group; an effective member must be a
+-- user).
+--
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'subjects_id_subject_type_key'
+    ) THEN
+        ALTER TABLE subjects
+            ADD CONSTRAINT subjects_id_subject_type_key UNIQUE (id, subject_type);
+    END IF;
+END$$;
+
+--
+-- The kinds of group the DE models, replacing the folder structure Grouper
+-- encoded in colon-delimited paths. owner_required distinguishes kinds that live
+-- under a user (teams, collaborator lists) from globally named ones.
+--
+CREATE TABLE IF NOT EXISTS group_types (
+    name varchar(32) NOT NULL,
+    description text NOT NULL,
+    owner_required boolean NOT NULL,
+    PRIMARY KEY (name),
+    -- Target of the composite foreign key from groups.
+    UNIQUE (name, owner_required)
+);
+
+COMMENT ON TABLE group_types IS
+    'The kinds of group the Discovery Environment models.';
+
+INSERT INTO group_types (name, description, owner_required) VALUES
+    ('collaborator_list', 'A user''s private list of collaborators.', true),
+    ('team', 'A user-created team that others may be invited to or may join.', true),
+    ('community', 'A curated, globally named community of DE users.', false),
+    ('system', 'A group managed by the DE itself, such as the group of all DE users.', false)
+    ON CONFLICT DO NOTHING;
+
+--
+-- A group is its subject row plus attributes: the primary key is the internal
+-- subjects.id, so a permission granted to a group can be expanded to its members
+-- without translating between identifier spaces. The externally visible group
+-- identifier is subjects.subject_id.
+--
+CREATE TABLE IF NOT EXISTS groups (
+    subject_id uuid NOT NULL,
+    subject_type subject_type_enum NOT NULL DEFAULT 'group'
+        CHECK (subject_type = 'group'),
+    group_type varchar(32) NOT NULL,
+    owner varchar(512) CHECK (owner IS NULL OR owner ~ '[^[:space:]]'),
+    -- Derived so the (group_type, owner) pairing can be enforced by a foreign
+    -- key into group_types rather than a hard-coded CHECK per kind.
+    owner_present boolean NOT NULL GENERATED ALWAYS AS (owner IS NOT NULL) STORED,
+    -- Grouper's "extension": the short name, unique within (group_type, owner).
+    -- Colons are rejected because they were Grouper's path separator and their
+    -- presence would mean a name that failed to parse during the import.
+    name varchar(255) NOT NULL
+        CHECK (name ~ '[^[:space:]]')
+        CHECK (name !~ ':'),
+    -- NULL means "display the name". Present so a label can diverge from the
+    -- identifier later without another migration.
+    display_name varchar(255),
+    description text NOT NULL DEFAULT '',
+    -- The full Grouper path this group was imported under, for provenance and
+    -- reconciliation. NULL for groups created after the migration.
+    legacy_name text,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now(),
+    PRIMARY KEY (subject_id),
+    FOREIGN KEY (subject_id, subject_type)
+        REFERENCES subjects (id, subject_type) ON DELETE CASCADE,
+    FOREIGN KEY (group_type, owner_present)
+        REFERENCES group_types (name, owner_required),
+    UNIQUE (legacy_name)
+);
+
+COMMENT ON TABLE groups IS
+    'Groups managed by the DE, replacing Grouper. Keyed on the internal subjects.id '
+    'of the group''s subject row; the external identifier is subjects.subject_id.';
+
+COMMENT ON COLUMN groups.owner IS
+    'Namespace segment (a username) frozen at creation. NOT the current owner of the '
+    'group, which is the ''own'' permission in the permissions table and may be transferred.';
+
+--
+-- Structured identity. coalesce rather than NULLS NOT DISTINCT so the index works
+-- on PostgreSQL before 15; owner is CHECKed non-blank, so the empty string cannot
+-- collide with a real owner. Names are compared case- and whitespace-insensitively,
+-- matching resource_types_name_unique in migration 000021.
+--
+CREATE UNIQUE INDEX IF NOT EXISTS groups_identity_unique
+    ON groups (
+        group_type,
+        lower(coalesce(owner, '')),
+        lower(trim(regexp_replace(name, '[[:space:]]+', ' ', 'g')))
+    );
+
+-- Listing a kind of group, optionally narrowed to one owner, in name order.
+CREATE INDEX IF NOT EXISTS groups_type_owner_name_idx
+    ON groups (group_type, owner, name);
+
+--
+-- Direct membership. A member may be a user or another group: nesting is in
+-- regular use and must be preserved.
+--
+CREATE TABLE IF NOT EXISTS group_memberships (
+    group_id uuid NOT NULL,
+    member_id uuid NOT NULL,
+    member_type subject_type_enum NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    -- Username of whoever added the membership. Not a foreign key: it is often a
+    -- service account, which is not a permissions subject.
+    added_by varchar(512),
+    PRIMARY KEY (group_id, member_id),
+    FOREIGN KEY (group_id) REFERENCES groups (subject_id) ON DELETE CASCADE,
+    FOREIGN KEY (member_id, member_type)
+        REFERENCES subjects (id, subject_type) ON DELETE CASCADE,
+    -- Direct self-membership. Longer cycles cannot be caught declaratively and
+    -- are rejected by the service before insert.
+    CHECK (group_id <> member_id)
+);
+
+COMMENT ON TABLE group_memberships IS
+    'Direct group membership. Members may be users or groups; the transitive '
+    'expansion is maintained in group_effective_members.';
+
+-- Walking from a member to the groups containing it: the ancestor traversal that
+-- decides which groups need their effective membership recomputed after a write.
+CREATE INDEX IF NOT EXISTS group_memberships_member_idx
+    ON group_memberships (member_id, group_id);
+
+--
+-- The transitive closure of group_memberships, restricted to users. Derived
+-- state, recomputed by the groups service inside the transaction that changes
+-- direct membership. It exists so that permission lookup -- the hottest query in
+-- the DE -- stays a plain join instead of a recursive CTE.
+--
+CREATE TABLE IF NOT EXISTS group_effective_members (
+    group_id uuid NOT NULL,
+    member_id uuid NOT NULL,
+    member_type subject_type_enum NOT NULL DEFAULT 'user'
+        CHECK (member_type = 'user'),
+    PRIMARY KEY (group_id, member_id),
+    FOREIGN KEY (group_id) REFERENCES groups (subject_id) ON DELETE CASCADE,
+    FOREIGN KEY (member_id, member_type)
+        REFERENCES subjects (id, subject_type) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE group_effective_members IS
+    'Derived: every user reachable from a group through any depth of nesting. '
+    'Maintained on write by the groups service; reconcile by recomputing from '
+    'group_memberships and diffing. Deleting a nested group cascades away the '
+    'membership row without updating this table, so the service must collect the '
+    'containing groups BEFORE issuing the delete and recompute them after -- once '
+    'the cascade fires, the path is gone and they can no longer be found. Stale '
+    'rows here grant access that direct membership no longer justifies.';
+
+-- The permission-lookup direction: given a user, which groups contain them.
+CREATE INDEX IF NOT EXISTS group_effective_members_member_idx
+    ON group_effective_members (member_id, group_id);
+
+--
+-- Every group that transitively contains any of the given groups, including the
+-- given groups themselves. This is the set whose closure a membership change
+-- invalidates. UNION rather than UNION ALL, so a cycle terminates instead of
+-- recursing forever.
+--
+CREATE OR REPLACE FUNCTION group_ancestors(group_ids uuid[])
+RETURNS SETOF uuid AS $$
+    WITH RECURSIVE up(id) AS (
+        SELECT unnest(group_ids)
+        UNION
+        SELECT gm.group_id
+          FROM group_memberships gm
+          JOIN up ON gm.member_id = up.id
+         WHERE gm.member_type = 'group'
+    )
+    SELECT id FROM up;
+$$ LANGUAGE sql STABLE;
+
+COMMENT ON FUNCTION group_ancestors(uuid[]) IS
+    'The given groups plus every group transitively containing them: the set to '
+    'pass to recompute_group_closure after a membership change.';
+
+--
+-- Rebuilds group_effective_members for exactly the given groups from the current
+-- direct membership. Callers are responsible for passing the full affected set,
+-- normally group_ancestors(changed_groups). The groups service calls this after
+-- membership writes and the delete trigger below calls it after detaching, so
+-- there is one implementation of the closure rather than one per caller.
+--
+CREATE OR REPLACE FUNCTION recompute_group_closure(group_ids uuid[])
+RETURNS void AS $$
+BEGIN
+    DELETE FROM group_effective_members WHERE group_id = ANY(group_ids);
+
+    INSERT INTO group_effective_members (group_id, member_id)
+    WITH RECURSIVE reachable(root, member_id, member_type) AS (
+        SELECT gm.group_id, gm.member_id, gm.member_type
+          FROM group_memberships gm
+         WHERE gm.group_id = ANY(group_ids)
+        UNION
+        SELECT r.root, gm.member_id, gm.member_type
+          FROM reachable r
+          JOIN group_memberships gm ON gm.group_id = r.member_id
+         WHERE r.member_type = 'group'
+    )
+    SELECT DISTINCT root, member_id FROM reachable WHERE member_type = 'user';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION recompute_group_closure(uuid[]) IS
+    'Rebuilds the effective membership of the given groups from direct membership.';
+
+--
+-- Deleting a group removes it from its containers by cascade, which would leave
+-- those containers still granting access to the deleted group's members. By the
+-- time an AFTER trigger or the calling service could react, the cascade has
+-- destroyed the path back to the containers. Detaching and recomputing here,
+-- before the row is gone, is the only point where they are still findable --
+-- and it covers deletes initiated by any caller, including a cascade from a
+-- subjects row.
+--
+CREATE OR REPLACE FUNCTION groups_detach_before_delete()
+RETURNS TRIGGER AS $$
+DECLARE
+    containers uuid[];
+BEGIN
+    SELECT array_agg(a) INTO containers
+      FROM group_ancestors(ARRAY[OLD.subject_id]) AS a
+     WHERE a <> OLD.subject_id;
+
+    -- Detach first so the recomputation observes the graph without this group.
+    DELETE FROM group_memberships WHERE member_id = OLD.subject_id;
+
+    IF containers IS NOT NULL THEN
+        PERFORM recompute_group_closure(containers);
+    END IF;
+
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_groups_detach_before_delete ON groups;
+CREATE TRIGGER trigger_groups_detach_before_delete
+    BEFORE DELETE ON groups
+    FOR EACH ROW
+    EXECUTE FUNCTION groups_detach_before_delete();
+
+-- Automatically maintain updated_at on row modification.
+CREATE OR REPLACE FUNCTION update_groups_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_groups_updated_at ON groups;
+CREATE TRIGGER trigger_groups_updated_at
+    BEFORE UPDATE ON groups
+    FOR EACH ROW
+    EXECUTE FUNCTION update_groups_updated_at();
+
+COMMIT;

--- a/migrations/000054_permissions_groups.up.sql
+++ b/migrations/000054_permissions_groups.up.sql
@@ -25,6 +25,55 @@ ALTER TABLE subjects
     ALTER COLUMN subject_id SET DEFAULT replace(uuid_generate_v1()::text, '-', '');
 
 --
+-- Correlates a user subject with its DE user row. subject_id is a bare username
+-- while public.users.username carries a domain suffix, so a join between the two
+-- otherwise has to reconstruct the suffixed form every time.
+--
+-- Nullable and best-effort by design: a subject can be created before the user
+-- has ever logged in to the DE, and 5 of the 19,728 production user subjects
+-- correspond to no DE user at all. A NULL means "not correlated", never "no such
+-- user", and consumers must not treat it as the latter.
+--
+-- ON DELETE SET NULL rather than CASCADE: removing a DE user must not remove the
+-- subject, because that would cascade away their group memberships and every
+-- permission ever granted to them.
+--
+-- Deliberately not backfilled here. Matching requires the username suffix, which
+-- is deployment-specific, so population belongs to the services and the Grouper
+-- importer, which have it configured.
+--
+ALTER TABLE subjects ADD COLUMN IF NOT EXISTS user_id uuid;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'subjects_user_id_fkey'
+    ) THEN
+        ALTER TABLE subjects
+            ADD CONSTRAINT subjects_user_id_fkey FOREIGN KEY (user_id)
+                REFERENCES public.users (id) ON DELETE SET NULL;
+    END IF;
+
+    -- Only a user subject can name a DE user; a group never does.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'subjects_user_id_is_user'
+    ) THEN
+        ALTER TABLE subjects
+            ADD CONSTRAINT subjects_user_id_is_user
+                CHECK (user_id IS NULL OR subject_type = 'user');
+    END IF;
+END$$;
+
+COMMENT ON COLUMN subjects.user_id IS
+    'The public.users row this subject corresponds to, or NULL when it has not been '
+    'correlated -- which is not the same as the user not existing.';
+
+-- At most one subject may claim a given DE user. The partial index leaves the
+-- uncorrelated rows out entirely rather than relying on NULL distinctness.
+CREATE UNIQUE INDEX IF NOT EXISTS subjects_user_id_unique
+    ON subjects (user_id) WHERE user_id IS NOT NULL;
+
+--
 -- Redundant with the primary key for uniqueness, but required as the target of
 -- the composite foreign keys below, which pin the subject type of a referencing
 -- row (a group's backing subject must be a group; an effective member must be a

--- a/migrations/000055_group_member_visibility.down.sql
+++ b/migrations/000055_group_member_visibility.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+ALTER TABLE groups DROP COLUMN IF EXISTS members_public;
+
+COMMIT;

--- a/migrations/000055_group_member_visibility.up.sql
+++ b/migrations/000055_group_member_visibility.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Grouper distinguished two kinds of public group, and collapsing them exposes
+-- membership that used to be private.
+--
+-- A public group is marked by a read grant held by the GrouperAll subject. In
+-- Grouper that grant arrived as one of two privileges: `viewers`, meaning the
+-- group is discoverable and joinable but its member list is not public, or
+-- `readers`, meaning the members are public too. Production applies `viewers`
+-- to public teams and `readers` to public communities.
+--
+-- The permissions service has no level weaker than `read`, so both import as
+-- the same grant and the distinction is lost -- which silently makes every
+-- public team's membership world-readable. It is recorded here instead, as a
+-- property of the group rather than a grant to a subject, because GrouperAll is
+-- a sentinel with no members rather than a real subject.
+--
+-- Defaults to false: a group whose members were not already public must not
+-- become public by being migrated.
+--
+ALTER TABLE groups
+    ADD COLUMN IF NOT EXISTS members_public boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN groups.members_public IS
+    'Whether a public group''s member list is public too. Grouper''s `readers` privilege for GrouperAll, as opposed to `viewers`. Meaningless unless the group carries a read grant to GrouperAll.';
+
+COMMIT;

--- a/migrations/000056_detach_skips_deleted_containers.down.sql
+++ b/migrations/000056_detach_skips_deleted_containers.down.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+-- Restores the form from 000054, which cannot delete a set of nested groups in
+-- one statement.
+CREATE OR REPLACE FUNCTION groups_detach_before_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+DECLARE
+    containers uuid[];
+BEGIN
+    SELECT array_agg(a) INTO containers
+      FROM group_ancestors(ARRAY[OLD.subject_id]) AS a
+     WHERE a <> OLD.subject_id;
+
+    DELETE FROM group_memberships WHERE member_id = OLD.subject_id;
+
+    IF containers IS NOT NULL THEN
+        PERFORM recompute_group_closure(containers);
+    END IF;
+
+    RETURN OLD;
+END;
+$$;
+
+COMMIT;

--- a/migrations/000056_detach_skips_deleted_containers.down.sql
+++ b/migrations/000056_detach_skips_deleted_containers.down.sql
@@ -15,6 +15,7 @@ BEGIN
       FROM group_ancestors(ARRAY[OLD.subject_id]) AS a
      WHERE a <> OLD.subject_id;
 
+    -- Detach first so the recomputation observes the graph without this group.
     DELETE FROM group_memberships WHERE member_id = OLD.subject_id;
 
     IF containers IS NOT NULL THEN

--- a/migrations/000056_detach_skips_deleted_containers.up.sql
+++ b/migrations/000056_detach_skips_deleted_containers.up.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Deleting several nested groups in one statement failed.
+--
+-- The BEFORE DELETE trigger recomputes the closure of every group containing
+-- the one being deleted. When a set of nested groups goes at once -- a cascade
+-- from subjects deletes them row by row -- a container can already be gone by
+-- the time its child is deleted, and recomputing it inserts group_effective_
+-- members rows for a group no longer in `groups`, violating the foreign key.
+-- The whole statement then fails, so the deletion cannot be performed at all.
+--
+-- A container that is itself being deleted has no closure worth rebuilding: its
+-- rows are cascading away regardless. Skipping those is enough, and leaves the
+-- single-group case, which is what the service does, unchanged.
+--
+CREATE OR REPLACE FUNCTION groups_detach_before_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+DECLARE
+    containers uuid[];
+BEGIN
+    SELECT array_agg(a) INTO containers
+      FROM group_ancestors(ARRAY[OLD.subject_id]) AS a
+     WHERE a <> OLD.subject_id
+       AND EXISTS (SELECT 1 FROM groups g WHERE g.subject_id = a);
+
+    -- Detach first so the recomputation observes the graph without this group.
+    DELETE FROM group_memberships WHERE member_id = OLD.subject_id;
+
+    IF containers IS NOT NULL THEN
+        PERFORM recompute_group_closure(containers);
+    END IF;
+
+    RETURN OLD;
+END;
+$$;
+
+COMMIT;

--- a/migrations/000057_lock_closure_recomputation.down.sql
+++ b/migrations/000057_lock_closure_recomputation.down.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+-- Restores the unlocked form from 000054, which loses concurrent membership
+-- writes and can leave a concurrently-attached parent permanently stale.
+CREATE OR REPLACE FUNCTION recompute_group_closure(group_ids uuid[]) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+BEGIN
+    DELETE FROM group_effective_members WHERE group_id = ANY(group_ids);
+
+    INSERT INTO group_effective_members (group_id, member_id)
+    WITH RECURSIVE reachable(root, member_id, member_type) AS (
+        SELECT gm.group_id, gm.member_id, gm.member_type
+          FROM group_memberships gm
+         WHERE gm.group_id = ANY(group_ids)
+        UNION
+        SELECT r.root, gm.member_id, gm.member_type
+          FROM reachable r
+          JOIN group_memberships gm ON gm.group_id = r.member_id
+         WHERE r.member_type = 'group'
+    )
+    SELECT DISTINCT root, member_id FROM reachable WHERE member_type = 'user';
+END;
+$$;
+
+COMMIT;

--- a/migrations/000057_lock_closure_recomputation.up.sql
+++ b/migrations/000057_lock_closure_recomputation.up.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Concurrent membership writes corrupted the closure, in two ways.
+--
+-- recompute_group_closure deletes a group's effective members and reinserts
+-- them. Under READ COMMITTED the DELETE blocks on a concurrent writer's locks
+-- and then re-evaluates, finding the rows gone, while the following INSERT
+-- takes a fresh snapshot that sees the other transaction's committed work. Two
+-- transactions recomputing a shared ancestor -- de-users is an ancestor of a
+-- great many groups -- collide on group_effective_members_pkey and one write is
+-- lost to a rollback.
+--
+-- The second is worse because it is silent: group_ancestors is computed from
+-- the writer's snapshot, so a parent being attached concurrently is invisible
+-- and never recomputed. Both transactions commit and the new member is
+-- permanently missing from the new parent's effective membership, so every
+-- permission granted to that parent silently fails to reach them.
+--
+-- Locking the groups whose closure is being rebuilt, in a deterministic order,
+-- serializes the recomputations that overlap and leaves disjoint ones
+-- concurrent. Ordering by id is what keeps two writers from deadlocking when
+-- their ancestor sets intersect in opposite orders.
+--
+CREATE OR REPLACE FUNCTION recompute_group_closure(group_ids uuid[]) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+BEGIN
+    PERFORM subject_id
+       FROM groups
+      WHERE subject_id = ANY(group_ids)
+      ORDER BY subject_id
+        FOR UPDATE;
+
+    DELETE FROM group_effective_members WHERE group_id = ANY(group_ids);
+
+    INSERT INTO group_effective_members (group_id, member_id)
+    WITH RECURSIVE reachable(root, member_id, member_type) AS (
+        SELECT gm.group_id, gm.member_id, gm.member_type
+          FROM group_memberships gm
+         WHERE gm.group_id = ANY(group_ids)
+        UNION
+        SELECT r.root, gm.member_id, gm.member_type
+          FROM reachable r
+          JOIN group_memberships gm ON gm.group_id = r.member_id
+         WHERE r.member_type = 'group'
+    )
+    SELECT DISTINCT root, member_id FROM reachable WHERE member_type = 'user';
+END;
+$$;
+
+COMMENT ON FUNCTION recompute_group_closure(uuid[]) IS
+    'Rebuilds the effective membership of the given groups. Locks them in id order first: concurrent recomputations of a shared ancestor otherwise collide on the primary key, and a concurrently-attached parent is never recomputed at all.';
+
+COMMIT;

--- a/migrations/000057_lock_closure_recomputation.up.sql
+++ b/migrations/000057_lock_closure_recomputation.up.sql
@@ -9,9 +9,9 @@ SET search_path = permissions, public, pg_catalog;
 -- them. Under READ COMMITTED the DELETE blocks on a concurrent writer's locks
 -- and then re-evaluates, finding the rows gone, while the following INSERT
 -- takes a fresh snapshot that sees the other transaction's committed work. Two
--- transactions recomputing a shared ancestor -- de-users is an ancestor of a
--- great many groups -- collide on group_effective_members_pkey and one write is
--- lost to a rollback.
+-- transactions recomputing a shared ancestor -- a community holding several
+-- nested groups is an ancestor of each of them -- collide on
+-- group_effective_members_pkey and one write is lost to a rollback.
 --
 -- The second is worse because it is silent: group_ancestors is computed from
 -- the writer's snapshot, so a parent being attached concurrently is invisible
@@ -21,8 +21,12 @@ SET search_path = permissions, public, pg_catalog;
 --
 -- Locking the groups whose closure is being rebuilt, in a deterministic order,
 -- serializes the recomputations that overlap and leaves disjoint ones
--- concurrent. Ordering by id is what keeps two writers from deadlocking when
--- their ancestor sets intersect in opposite orders.
+-- concurrent. Ordering by id keeps two recomputations from deadlocking when
+-- their ancestor sets intersect in opposite orders. It does not rule deadlock
+-- out entirely: the membership triggers and the tuple lock of a group DELETE
+-- acquire groups rows outside this ordering, so concurrent bulk writes can
+-- still abort with 40P01 -- an availability cost, not a correctness one, and
+-- the caller's remedy is to retry the transaction.
 --
 CREATE OR REPLACE FUNCTION recompute_group_closure(group_ids uuid[]) RETURNS void
     LANGUAGE plpgsql

--- a/migrations/000058_group_joinable.down.sql
+++ b/migrations/000058_group_joinable.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+ALTER TABLE groups DROP COLUMN IF EXISTS joinable;
+
+COMMIT;

--- a/migrations/000058_group_joinable.up.sql
+++ b/migrations/000058_group_joinable.up.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Whether a group can be joined without approval is a third thing, distinct
+-- from being public and from exposing its members.
+--
+-- Grouper spent three privileges on the all-users subject: `viewers` (the group
+-- is discoverable), `readers` (its membership is listable), and `optins` (a user
+-- may add themselves). The DE gave public communities `read` + `optin` and
+-- public teams `view` alone, so Grouper refused a self-join on a public team --
+-- teams use the join-request flow, where an administrator approves.
+--
+-- Collapsing optin into either of the others loses that: with only the public
+-- marker to go on, every public team becomes directly joinable and the approval
+-- workflow is bypassed. members_public looks like a usable proxy because the two
+-- coincide in current data, but it records `readers` and means something else.
+--
+-- Defaults to false: migrating must not make a group joinable that was not.
+--
+ALTER TABLE groups
+    ADD COLUMN IF NOT EXISTS joinable boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN groups.joinable IS
+    'Whether a user may add themselves to this group without approval. Grouper''s `optins` privilege for GrouperAll, as opposed to `viewers` (discoverable) or `readers` (members listable). Meaningless unless the group also carries a read grant to GrouperAll.';
+
+COMMIT;

--- a/migrations/000059_lock_nested_member_on_attach.down.sql
+++ b/migrations/000059_lock_nested_member_on_attach.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+SET search_path = permissions, public, pg_catalog;
+DROP TRIGGER IF EXISTS group_memberships_lock_nested_member ON group_memberships;
+DROP FUNCTION IF EXISTS group_memberships_lock_nested_member();
+COMMIT;

--- a/migrations/000059_lock_nested_member_on_attach.up.sql
+++ b/migrations/000059_lock_nested_member_on_attach.up.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Attaching a group to a new parent, concurrently with a membership change
+-- inside that group, left the new parent permanently stale -- silently.
+--
+-- 000057 serializes recomputations that share a group, which fixes the case
+-- where two writers rebuild the same ancestor. It cannot fix this one: the two
+-- writers lock disjoint sets. One recomputes A and its ancestors, which do not
+-- yet include Q; the other attaches A under Q and recomputes Q, reading A's
+-- membership from a snapshot that does not yet include the new member. Both
+-- commit, and nothing ever recomputes Q again.
+--
+-- Reproduced: A holds one member, Q is standalone. T1 adds a member to A and
+-- recomputes; T2 concurrently nests A under Q and recomputes Q. Afterwards A
+-- has both members and Q has only the first.
+--
+-- The two do share one object -- the group being attached. Locking it when a
+-- nested membership is written gives them a meeting point: the attach waits for
+-- an in-flight recomputation of that group, and then reads its committed
+-- membership.
+--
+CREATE OR REPLACE FUNCTION group_memberships_lock_nested_member() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+BEGIN
+    IF NEW.member_type = 'group' THEN
+        PERFORM subject_id FROM groups WHERE subject_id = NEW.member_id FOR UPDATE;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION group_memberships_lock_nested_member() IS
+    'Locks a group as it is attached to a parent, so the attach serializes against any concurrent recomputation of that group. Without it the new parent misses members added concurrently, permanently and with no error.';
+
+DROP TRIGGER IF EXISTS group_memberships_lock_nested_member ON group_memberships;
+CREATE TRIGGER group_memberships_lock_nested_member
+    BEFORE INSERT ON group_memberships
+    FOR EACH ROW EXECUTE FUNCTION group_memberships_lock_nested_member();
+
+COMMIT;

--- a/migrations/000060_lock_membership_detach.down.sql
+++ b/migrations/000060_lock_membership_detach.down.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+DROP TRIGGER IF EXISTS trigger_group_memberships_lock_for_closure ON group_memberships;
+DROP FUNCTION IF EXISTS group_memberships_lock_for_closure();
+
+-- Restores the insert-only lock from 000059.
+CREATE OR REPLACE FUNCTION group_memberships_lock_nested_member() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+BEGIN
+    IF NEW.member_type = 'group' THEN
+        PERFORM subject_id FROM groups WHERE subject_id = NEW.member_id FOR UPDATE;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION group_memberships_lock_nested_member() IS
+    'Locks a group as it is attached to a parent, so the attach serializes against any concurrent recomputation of that group. Without it the new parent misses members added concurrently, permanently and with no error.';
+
+DROP TRIGGER IF EXISTS group_memberships_lock_nested_member ON group_memberships;
+CREATE TRIGGER group_memberships_lock_nested_member
+    BEFORE INSERT ON group_memberships
+    FOR EACH ROW EXECUTE FUNCTION group_memberships_lock_nested_member();
+
+-- Restores the 000054 comment.
+COMMENT ON TABLE group_effective_members IS
+    'Derived: every user reachable from a group through any depth of nesting. '
+    'Maintained on write by the groups service; reconcile by recomputing from '
+    'group_memberships and diffing. Deleting a nested group cascades away the '
+    'membership row without updating this table, so the service must collect the '
+    'containing groups BEFORE issuing the delete and recompute them after -- once '
+    'the cascade fires, the path is gone and they can no longer be found. Stale '
+    'rows here grant access that direct membership no longer justifies.';
+
+COMMIT;

--- a/migrations/000060_lock_membership_detach.up.sql
+++ b/migrations/000060_lock_membership_detach.up.sql
@@ -1,0 +1,79 @@
+BEGIN;
+
+SET search_path = permissions, public, pg_catalog;
+
+--
+-- Removing a member, concurrently with the group being attached to a new
+-- parent, left the parent's closure permanently stale -- the same silent
+-- failure 000059 fixed for additions, in the over-permissive direction: the
+-- removed user kept every permission granted to the new parent.
+--
+-- 000059 works for additions for a reason it did not state: inserting a
+-- membership row takes an FK KEY SHARE lock on the group's row, which
+-- conflicts with the attach trigger's FOR UPDATE, so the two writers meet. A
+-- DELETE performs no referential-integrity check and takes no lock at all on
+-- the group row, so the remover never waits for an in-flight attach and its
+-- ancestor set is computed from a snapshot that predates it.
+--
+-- One function now takes the locks for every membership write. On INSERT or
+-- UPDATE it locks a group-typed member as before, and additionally refuses a
+-- group-typed member with no groups row -- reachable only by direct SQL, but
+-- silently orphaned closure rows are worth an error. On DELETE it locks the
+-- group being detached from, and the member itself when the member is a
+-- group, so removals serialize against concurrent attaches of either side.
+--
+-- Callers must still write the membership change first and only then compute
+-- group_ancestors and recompute, in the same transaction: the ancestor query
+-- reads a fresh snapshot only after these locks have forced any concurrent
+-- attach to commit or wait.
+--
+CREATE OR REPLACE FUNCTION group_memberships_lock_for_closure() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = permissions, public, pg_catalog
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        -- The group row may already be gone when this fires from the groups
+        -- delete cascade; there is nothing left to serialize against then.
+        PERFORM subject_id FROM groups WHERE subject_id = OLD.group_id FOR UPDATE;
+        IF OLD.member_type = 'group' THEN
+            PERFORM subject_id FROM groups WHERE subject_id = OLD.member_id FOR UPDATE;
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    IF NEW.member_type = 'group' THEN
+        PERFORM subject_id FROM groups WHERE subject_id = NEW.member_id FOR UPDATE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'group-typed member % has no groups row; the member group does not exist or was deleted concurrently', NEW.member_id
+                USING ERRCODE = 'foreign_key_violation';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION group_memberships_lock_for_closure() IS
+    'Locks the groups a membership write touches so concurrent closure recomputations serialize instead of losing each other''s work. Covers both directions: an attach waits for recomputations of the group being attached, and a removal waits for an in-flight attach of the group it detaches from.';
+
+DROP TRIGGER IF EXISTS group_memberships_lock_nested_member ON group_memberships;
+DROP FUNCTION IF EXISTS group_memberships_lock_nested_member();
+
+DROP TRIGGER IF EXISTS trigger_group_memberships_lock_for_closure ON group_memberships;
+CREATE TRIGGER trigger_group_memberships_lock_for_closure
+    BEFORE INSERT OR UPDATE OR DELETE ON group_memberships
+    FOR EACH ROW EXECUTE FUNCTION group_memberships_lock_for_closure();
+
+-- The 000054 comment told the service to collect containers before deleting a
+-- group, which groups_detach_before_delete has done automatically since then;
+-- following the old instruction would double-recompute.
+COMMENT ON TABLE group_effective_members IS
+    'Derived: every user reachable from a group through any depth of nesting. '
+    'Maintained by the groups service, which must write the direct membership '
+    'change first and then recompute the ancestors'' closures in the same '
+    'transaction. Group deletion is handled by the trigger on groups, which '
+    'detaches and recomputes the containers itself. Reconcile by recomputing '
+    'from group_memberships and diffing; stale rows here grant access that '
+    'direct membership no longer justifies.';
+
+COMMIT;


### PR DESCRIPTION
Migration `000054`, the storage half of moving DE group data out of Grouper and
into the `permissions` schema of the DE database. Groups sit beside the tables
the permissions service owns so that expanding a subject to its groups becomes a
join inside the permission lookup rather than a call to another service.

No service depends on this yet — the `groups` service reads it, but is not
deployed anywhere. It is safe to apply and roll back on its own.

## What it adds

- **`group_types`** — reference rows (`collaborator_list`, `team`, `community`,
  `system`) with an `owner_required` flag, so adding a kind is an INSERT rather
  than a migration.
- **`groups`** — keyed on the internal `subjects.id`, so a permission granted to
  a group expands to its members without translating between identifier spaces.
  The external identifier stays `subjects.subject_id`. Identity is structured
  (type / owner / short name) rather than Grouper's colon-delimited paths, and
  `legacy_name` keeps the Grouper path for provenance.
- **`group_memberships`** — direct membership. Members may be users *or* groups:
  production Grouper has 156 nested memberships, across collaborator lists,
  teams, and communities, so nesting had to be preserved.
- **`group_effective_members`** — the materialized transitive closure, restricted
  to users. Permission lookup is the hottest query in the DE, so the expansion is
  precomputed on write instead of recursing at read time.
- **`group_ancestors()` / `recompute_group_closure()`** — one implementation of
  the closure, shared by the service and the delete trigger.
- **`trigger_groups_detach_before_delete`** — see below.
- **`subjects.user_id`** — a nullable correlation to `public.users`.

## Two changes to `subjects` worth attention

`subject_id` widens from `varchar(64)` to `varchar(512)`, matching
`public.users.username`. QA already has a 65-character username, and membership
now requires every member to have a subject row, so that user would otherwise
fail a constraint they do not hit today.

`subject_id` also gains a default of `replace(uuid_generate_v1()::text,'-','')`.
Groups imported from Grouper keep their original 32-hex identifiers so existing
permission grants and iRODS `@grouper-<id>` names stay valid; groups created
after the migration must be indistinguishable from them, or the DE ends up with
two identifier shapes and two iRODS group-name shapes.

## The delete trigger is load-bearing

Deleting a nested group cascades its membership row away, which destroys the path
back to the containing groups before any AFTER trigger or calling service could
react — leaving those groups still granting access to the deleted group's
members. This was verified as a real leak before the fix. A `BEFORE DELETE`
trigger detaches and recomputes at the one point the containers are still
findable, and covers every caller including a cascade from `subjects`.

## `subjects.user_id`

`subject_id` is a bare username while `public.users.username` carries a domain
suffix, so joining the two means reconstructing the suffixed form everywhere.

It is **nullable and best-effort**: a subject can be created before the user has
ever logged in to the DE, and 5 of the 19,728 production user subjects correspond
to no DE user at all. A NULL means "not correlated", never "no such user".

`ON DELETE SET NULL` rather than CASCADE — removing a DE user must not delete the
subject, because that would cascade away their group memberships and every
permission granted to them. A CHECK stops a group subject from naming a user, and
a partial unique index stops two subjects claiming the same one.

It is deliberately **not backfilled here**: matching needs the username suffix,
which is deployment-specific. Population belongs to the services and the Grouper
importer, which have it configured. Match on the fully suffixed username rather
than the bare name — production `public.users` holds 128,110 rows of a
doubled-suffix form (`user@@iplantcollaborative.org`) which are near-inert (34
jobs between all of them, against 1,477,921 for the 142,368 real rows) but would
make a bare-name match ambiguous for almost every user.

## Compatibility

- `NULLS NOT DISTINCT` is avoided in favour of a `coalesce`-based unique index,
  so the migration does not require PostgreSQL 15+.
- Both recursive CTEs use `UNION` rather than `UNION ALL`, so a membership cycle
  terminates instead of recursing forever. The service also rejects cycles at
  write time.

## Verification

`up` / `down` / `up` against a fresh PostgreSQL 18 database with all preceding
migrations applied. The down migration restores `subject_id` to `varchar(64)`,
failing rather than truncating if a longer identifier exists — silently
discarding part of an identity is worse than refusing to roll back.

The constraints were exercised individually against a clean database, and the
delete-trigger behaviour is covered by integration tests in the `groups` service
(dropping the trigger produces exactly the two expected failures).

## `group_data_source`

The importer reconciles — it removes memberships and grants Grouper no longer
has — which is correct only while Grouper is authoritative. Run it once after
cutover and it deletes whatever was created natively in the meantime.

A single-row table records which system owns group data, seeded to `grouper`.
The importer will refuse to start unless it says so. There is deliberately no
override flag: the only way to run a destructive reconcile afterwards is to set
this back, which is an attributed, timestamped write rather than something typed
at the end of an argument list. Flipping it to `native` is an ordered step of
cutover, performed before anything is pointed at the new store.

A `BEFORE UPDATE` trigger maintains `changed_at`, so the record of when cutover
happened cannot be left stale — verified by confirming an explicit
`changed_at = '2020-01-01'` is overridden.

Single-row-ness, the `source` vocabulary, and a non-blank `changed_by` are all
enforced by constraints and were exercised individually against a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
