### PR TITLE
Add a migration to add an initial time limit, for setting a job duration at launch

### DIFF
--- a/migrations/000054_jobs_initial_time_limit.down.sql
+++ b/migrations/000054_jobs_initial_time_limit.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE ONLY jobs
+    DROP COLUMN initial_time_limit_seconds;
+
+COMMIT;

--- a/migrations/000054_jobs_initial_time_limit.up.sql
+++ b/migrations/000054_jobs_initial_time_limit.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Add initial_time_limit_seconds to jobs to store the user-selected initial
+-- duration (in seconds) at analysis launch time. NULL means no override was
+-- provided and the tool-derived default will be used by timelord.
+--
+ALTER TABLE ONLY jobs
+    ADD COLUMN initial_time_limit_seconds INTEGER;
+
+COMMIT;


### PR DESCRIPTION
timelord will use this if non-null, otherwise calculates the initial duration normally.