### PR TITLE
Add the schema for moving notifications into the de database

### DIFF
--- a/migrations/000055_notification_types_table.down.sql
+++ b/migrations/000055_notification_types_table.down.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+-- Restores the notification_types enum. This only succeeds while every
+-- tool_types row still uses one of the original seven values; an enum has no
+-- equivalent of 'request' or 'community'.
+ALTER TABLE ONLY tool_types
+    ADD COLUMN IF NOT EXISTS notification_type_name text;
+
+UPDATE tool_types tt
+SET notification_type_name = nt.name
+FROM notification_types nt
+WHERE nt.id = tt.notification_type_id;
+
+ALTER TABLE ONLY tool_types
+    DROP CONSTRAINT IF EXISTS tool_types_notification_type_id_fkey,
+    DROP COLUMN IF EXISTS notification_type_id;
+
+DROP TABLE IF EXISTS notification_types;
+
+CREATE TYPE notification_types AS ENUM (
+    'apps',
+    'tool_request',
+    'team',
+    'data',
+    'analysis',
+    'tools',
+    'permanent_id_request'
+);
+
+ALTER TABLE ONLY tool_types
+    ADD COLUMN IF NOT EXISTS notification_type notification_types;
+
+UPDATE tool_types SET notification_type = notification_type_name::notification_types;
+
+ALTER TABLE ONLY tool_types
+    ALTER COLUMN notification_type SET NOT NULL,
+    DROP COLUMN IF EXISTS notification_type_name;
+
+COMMIT;

--- a/migrations/000055_notification_types_table.up.sql
+++ b/migrations/000055_notification_types_table.up.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Replaces the notification_types enum with a lookup table so the DE database
+-- and the notifications service share one vocabulary instead of two. The enum
+-- declared which notification a tool type produces; the table registered what
+-- the notifications service received. They are the same strings: apps passes
+-- tool_types.notification_type as the "type" field of the AMQP message that
+-- the notifications service then registers by name.
+--
+-- The enum cannot be dropped while a column still uses it, and the table
+-- cannot take the name until the enum is gone, so the values round-trip
+-- through text.
+--
+ALTER TABLE ONLY tool_types
+    ADD COLUMN IF NOT EXISTS notification_type_name text;
+
+UPDATE tool_types SET notification_type_name = notification_type::text;
+
+ALTER TABLE ONLY tool_types
+    DROP COLUMN IF EXISTS notification_type;
+
+DROP TYPE IF EXISTS notification_types;
+
+CREATE TABLE IF NOT EXISTS notification_types (
+    id uuid NOT NULL DEFAULT uuid_generate_v1(),
+    name varchar(32) NOT NULL UNIQUE,
+    PRIMARY KEY (id)
+);
+
+-- The first seven values came from the enum. 'request' and 'community' have
+-- only ever existed in the notifications database.
+INSERT INTO notification_types (name) VALUES
+    ('apps'),
+    ('tool_request'),
+    ('team'),
+    ('data'),
+    ('analysis'),
+    ('tools'),
+    ('permanent_id_request'),
+    ('request'),
+    ('community')
+ON CONFLICT (name) DO NOTHING;
+
+ALTER TABLE ONLY tool_types
+    ADD COLUMN IF NOT EXISTS notification_type_id uuid;
+
+UPDATE tool_types tt
+SET notification_type_id = nt.id
+FROM notification_types nt
+WHERE nt.name = tt.notification_type_name;
+
+-- Separate statement: ADD CONSTRAINT has no IF NOT EXISTS guard, so we check
+-- pg_constraint to make the migration idempotent.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'tool_types_notification_type_id_fkey'
+    ) THEN
+        ALTER TABLE tool_types
+            ADD CONSTRAINT tool_types_notification_type_id_fkey
+            FOREIGN KEY (notification_type_id) REFERENCES notification_types(id);
+    END IF;
+END$$;
+
+ALTER TABLE ONLY tool_types
+    ALTER COLUMN notification_type_id SET NOT NULL,
+    DROP COLUMN IF EXISTS notification_type_name;
+
+COMMIT;

--- a/migrations/000056_notifications.down.sql
+++ b/migrations/000056_notifications.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+-- Destructive: any rows loaded by the notifications_db_merge playbook are
+-- lost. Reverting after the cutover means restoring from the dump that
+-- playbook leaves behind.
+DROP INDEX IF EXISTS notifications_time_created_index;
+DROP INDEX IF EXISTS notifications_notification_type_id_index;
+DROP INDEX IF EXISTS notifications_user_id_index;
+DROP TABLE IF EXISTS notifications;
+
+COMMIT;

--- a/migrations/000056_notifications.up.sql
+++ b/migrations/000056_notifications.up.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Brings the notifications database into the DE database. The table is the
+-- notifications-db v2 schema unchanged except for its two foreign keys: the
+-- standalone database kept its own users table, and this one shares
+-- public.users with the rest of the DE.
+--
+-- The row data is not moved here -- a migration cannot reach across databases.
+-- See the notifications_db_merge playbook in the deployments repository.
+--
+CREATE TABLE IF NOT EXISTS notifications (
+    id uuid NOT NULL DEFAULT uuid_generate_v1(),
+    notification_type_id uuid NOT NULL,
+    -- public.users stores fully qualified usernames. The JSON payloads below
+    -- carry the bare username and are served to clients verbatim, so the two
+    -- spellings coexist by design; do not rewrite the payloads to match.
+    user_id uuid NOT NULL,
+    subject text NOT NULL,
+    seen boolean NOT NULL DEFAULT false,
+    deleted boolean NOT NULL DEFAULT false,
+    time_created timestamp with time zone NOT NULL DEFAULT now(),
+    -- As received from the AMQP message.
+    incoming_json jsonb NOT NULL,
+    -- As served by the API. NULL until the notification has been formatted.
+    outgoing_json jsonb,
+    routing_key varchar(64),
+    PRIMARY KEY (id),
+    FOREIGN KEY (notification_type_id) REFERENCES notification_types(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Supports the per-user listing endpoints, which are the service's hot path.
+CREATE INDEX IF NOT EXISTS notifications_user_id_index
+    ON notifications (user_id);
+
+-- Supports filtering a listing to a single notification type.
+CREATE INDEX IF NOT EXISTS notifications_notification_type_id_index
+    ON notifications (notification_type_id);
+
+-- Supports the time-ordered listing and its keyset pagination boundaries.
+CREATE INDEX IF NOT EXISTS notifications_time_created_index
+    ON notifications (time_created);
+
+COMMIT;


### PR DESCRIPTION
Creates the DE-side schema for folding the standalone notifications database into `de`. **No rows move here** — a migration can't reach across databases. The data move is [cyverse-de/deployments#notifications-db-merge](https://github.com/cyverse-de/deployments/tree/notifications-db-merge).

Numbered off `main`. These collide with 000055–000060 on the grouper-removal branches, which will be rebased and renumbered separately.

## 000055 — `notification_types` enum → lookup table

The DE enum and the notifications database's table are the same vocabulary declared twice. `apps` passes `tool_types.notification_type` as the `type` field of the AMQP message that the notifications service then registers by name — producer-side declaration and consumer-side registry of one string. They can't coexist under one name, since PostgreSQL shares a namespace between types and relations.

Converting *toward the table* rather than extending the enum:

- leaves the notifications service's type handling completely untouched (it keeps its table, its join, and its auto-registration insert)
- costs one added join in `get-app-notification-types` (`apps/src/apps/persistence/app_metadata.clj:400`), the only reader of that column anywhere in the codebase
- avoids a real dead end: `ALTER TYPE ... ADD VALUE` cannot be *used* in the transaction that adds it, and all 54 existing migrations open one

The ordering is fiddly — the type can't be dropped while the column exists, and the table can't take the name until the type is gone — so the values round-trip through a text column.

## 000056 — `public.notifications`

The notifications-db v2 schema unchanged except for its foreign keys: the standalone database kept its own `users` table, this one shares `public.users`. Three indexes carried over as-is.

## Verification

Against a restore of QA's `de` in the local cluster (1.1 GB, 111 tables, 7 views, 258,300 users, migration 54), applied with `golang-migrate` 4.19.0:

| check | result |
|---|---|
| `migrate up` 54→56 | 8.2 ms + 12.0 ms |
| `migrate down 2` → 54 | clean, enum restored, never dirty |
| `migrate up` again | clean |
| `tool_types` after round-trip | byte-identical |
| all 7 view definitions | `pg_get_viewdef` md5 unchanged |
| views queryable | same row counts, incl. 120,708 in `app_category_listing` |

Query equivalence was checked directly: the old shape run against untouched QA and the new shape against the converted restore return **identical results across all 10,144 app versions**. No app version yields more than one distinct type, so the `first` call in `get-notification-type` — which the source comment admits is arbitrary — can't change answer under the added join.

## Follow-up, not in this PR

`apps` needs the one-join change to `get-app-notification-types` before 000055 is deployed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)